### PR TITLE
Fix #207, track cancelled interactions

### DIFF
--- a/extension/background/main.js
+++ b/extension/background/main.js
@@ -17,6 +17,8 @@ this.main = (function() {
       return intents.muting.temporaryMute();
     } else if (message.type === "microphoneStopped") {
       return intents.muting.temporaryUnmute();
+    } else if (message.type === "cancelledIntent") {
+      return telemetry.cancelledIntent();
     } else if (message.type === "addTelemetry") {
       return telemetry.add(message.properties);
     } else if (message.type === "sendTelemetry") {

--- a/extension/background/telemetry.js
+++ b/extension/background/telemetry.js
@@ -17,8 +17,7 @@ this.telemetry = (function() {
   function resetPing() {
     ping = Object.assign({}, pingTemplate);
     ping.extensionTemporaryInstall = main.extensionTemporaryInstall();
-    lastIntentId = util.randomString(10);
-    ping.intentId = lastIntentId;
+    ping.intentId = util.randomString(10);
     if (ping.extensionTemporaryInstall) {
       ping.extensionInstallationChannel = "web-ext";
     }
@@ -50,8 +49,16 @@ this.telemetry = (function() {
     }
   };
 
+  exports.cancelledIntent = function() {
+    exports.add({ inputCancelled: true });
+    exports.send();
+  };
+
   // See https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/collection/webextension-api.html
   exports.send = function() {
+    if (!ping.inputCancelled) {
+      lastIntentId = ping.intentId;
+    }
     browser.telemetry.submitPing("voice", ping, {
       addClientId: true,
       addEnvironment: true,


### PR DESCRIPTION
Also fix up lastIntentId tracking, both to keep it from being overwritten by an incompleted interaction, or to be overwritten by a cancelled input.