### PR TITLE
Fix #221, avoid duplicate commands

### DIFF
--- a/extension/background/main.js
+++ b/extension/background/main.js
@@ -4,6 +4,13 @@ this.main = (function() {
   const exports = {};
 
   browser.runtime.onMessage.addListener(async (message, sender) => {
+    const properties = Object.assign({}, message);
+    delete properties.type;
+    let propString = "";
+    if (Object.keys(properties).length) {
+      propString = ` ${JSON.stringify(properties)}`;
+    }
+    log.debug(`Message ${message.type}${propString}`);
     if (message.type === "runIntent") {
       const desc = intentParser.parse(message.text);
       return intentRunner.runIntent(desc);

--- a/extension/recorder/recorder.html
+++ b/extension/recorder/recorder.html
@@ -9,6 +9,14 @@
     <div id="acquiring">Acquiring microphone...</div>
     <div id="recording">Recording...</div>
     <div id="paused">Paused...</div>
+    <div id="error">
+      <h1>Error</h1>
+      <p id="errorMessage"></p>
+      <p>
+        You may need to remove microphone permission (using the URL bar) and
+        manually reload this page.
+      </p>
+    </div>
     <script src="../log.js"></script>
     <script src="../util.js"></script>
     <script src="../popup/vad.js"></script>


### PR DESCRIPTION
The explicit mediaStopped() call wasn't necessary.

Also add guards so that calls to an out-of-date recorder method won't fire.

Also add some additional feedback in the recorder page when there's an error acquiring the microphone.