### PR TITLE
Second attempt at fixing #238

### DIFF
--- a/extension/popup/ui.js
+++ b/extension/popup/ui.js
@@ -53,20 +53,14 @@ this.ui = (function() {
   };
 
   function detectText(e) {
-    if (e.keyCode === 224 || e.keyCode === 17) {
-      // 224 is the key code for the Mac Command key
-      // 17 is the key code for Ctrl (not verified)
-      console.log("skipping text input");
-      return;
-    }
-    if (!textInputDetected) {
+    const fieldValue = document.getElementById("text-input-field").value;
+    if (!textInputDetected && fieldValue) {
       exports.setState("typing");
       textInputDetected = true;
       exports.onStartTextInput();
     }
     if (e.keyCode === 13) {
-      const textQuery = document.getElementById("text-input-field").value;
-      exports.onTextInput(textQuery);
+      exports.onTextInput(fieldValue);
     }
   }
 


### PR DESCRIPTION
Rather than catching certain keys, we instead make sure that text is in the field before consider it typing. This way any unprintable key (Command, Alt, etc) doesn't start the typing.