### PR TITLE
Fix #193, reload popup so text box contents aren't preserved

### DIFF
--- a/extension/popup/ui.js
+++ b/extension/popup/ui.js
@@ -176,7 +176,7 @@ this.ui = (function() {
   function listenForBack() {
     const backIcon = document.getElementById("back-icon");
     backIcon.addEventListener("click", () => {
-      location.reload();
+      location.href = `${location.pathname}?${Date.now()}`;
     });
   }
 


### PR DESCRIPTION
Previously we just used location.reload(), which left the text field in-tact (with the old query)