### PR TITLE
Fix #319, use current tab to prioritize some service selection

### DIFF
--- a/extension/background/intentRunner.js
+++ b/extension/background/intentRunner.js
@@ -111,7 +111,10 @@ this.intentRunner = (function() {
         `Running intent ${desc.name}`,
         Object.keys(desc.slots).length
           ? `with slots: ${JSON.stringify(desc.slots)}`
-          : "with no slots"
+          : "with no slots",
+        Object.keys(desc.parameters).length
+          ? `and parameters: ${JSON.stringify(desc.parameters)}`
+          : "and no params"
       );
       await intent.run(context);
       if (context.closePopupOnFinish) {
@@ -154,6 +157,7 @@ this.intentRunner = (function() {
           phrase: m.phrase,
           slots: m.slots,
           regex: String(m.regex),
+          parameters: m.parameters,
         };
       });
       if (intent.examples) {
@@ -166,6 +170,7 @@ this.intentRunner = (function() {
             parsedIntent: parsed.name,
             text: e,
             slots: parsed.slots,
+            parameters: parsed.parameters,
           };
         });
       }

--- a/extension/background/serviceList.js
+++ b/extension/background/serviceList.js
@@ -218,6 +218,17 @@ this.serviceList = (function() {
     }
   };
 
+  exports.detectServiceFromActiveTab = async function(services) {
+    const tab = (await browser.tabs.query({ active: true }))[0];
+    for (const name in services) {
+      const service = services[name];
+      if (tab.url.startsWith(service.baseUrl)) {
+        return name;
+      }
+    }
+    return null;
+  };
+
   exports.detectServiceFromHistory = async function(services) {
     const now = Date.now();
     const oneMonth = now - 1000 * 60 * 60 * 24 * 30; // last 30 days
@@ -252,9 +263,16 @@ this.serviceList = (function() {
     return best;
   };
 
-  exports.getService = async function(serviceType, serviceMap) {
+  exports.getService = async function(serviceType, serviceMap, options) {
     // TODO: serviceType should be used to store a preference related to this service
     // (which would override any automatic detection).
+    options = options || {};
+    if (options.lookAtCurrentTab) {
+      const serviceName = await exports.detectServiceFromActiveTab(serviceMap);
+      if (serviceName) {
+        return serviceMap[serviceName];
+      }
+    }
     const serviceName = await exports.detectServiceFromHistory(serviceMap);
     return serviceMap[serviceName];
   };

--- a/extension/intents/music/music.js
+++ b/extension/intents/music/music.js
@@ -16,7 +16,7 @@ this.intents.music = (function() {
     SERVICES[service.id] = service;
   };
 
-  async function getService(context) {
+  async function getService(context, options) {
     let ServiceClass;
     if (context.slots.service) {
       ServiceClass = SERVICES[context.slots.service.toLowerCase()];
@@ -26,7 +26,7 @@ this.intents.music = (function() {
         );
       }
     } else {
-      ServiceClass = await serviceList.getService("music", SERVICES);
+      ServiceClass = await serviceList.getService("music", SERVICES, options);
     }
     return new ServiceClass(context);
   }
@@ -49,7 +49,7 @@ this.intents.music = (function() {
     play [query]
     `,
     async run(context) {
-      const service = await getService(context);
+      const service = await getService(context, { lookAtCurrentTab: true });
       await service.playQuery(context.slots.query);
       // FIXME: this won't pause other YouTube tabs when you play a new YouTube tab,
       // though maybe YouTube should handle that itself?
@@ -89,7 +89,7 @@ this.intents.music = (function() {
     `,
     priority: "high",
     async run(context) {
-      const service = await getService(context);
+      const service = await getService(context, { lookAtCurrentTab: true });
       await service.unpause();
     },
   });
@@ -108,6 +108,22 @@ this.intents.music = (function() {
     async run(context) {
       const service = await getService(context);
       await service.activateOrOpen();
+    },
+  });
+
+  intentRunner.registerIntent({
+    name: "music.move",
+    examples: ["next", "previous"],
+    match: `
+    play next (song | track |)        [direction=next]
+    next (song | track |)             [direction=next]
+    play previous (song | track |)    [direction=back]
+    previous (song | track |)         [direction=back]
+    skip (song | track |)             [direction=next]
+    `,
+    async run(context) {
+      const service = await getService(context, { lookAtCurrentTab: true });
+      await service.move(context.parameters.direction);
     },
   });
 

--- a/extension/services/spotify/player.js
+++ b/extension/services/spotify/player.js
@@ -37,7 +37,23 @@ this.player = (function() {
     }
 
     action_pause() {
-      const button = document.querySelector("button[title='Pause']");
+      const button = this.querySelector("button[title='Pause']");
+      button.click();
+    }
+
+    action_unpause() {
+      const button = this.querySelector(".control-button[title='Play']");
+      button.click();
+    }
+
+    action_move({ direction }) {
+      let selector;
+      if (direction === "next") {
+        selector = ".control-button[title='Next']";
+      } else if (direction === "previous") {
+        selector = ".control-button[title='Previous']";
+      }
+      const button = this.querySelector(selector);
       button.click();
     }
   }

--- a/extension/services/spotify/spotify.js
+++ b/extension/services/spotify/spotify.js
@@ -23,6 +23,19 @@ this.services.spotify = (function() {
       }
     }
 
+    async move(direction) {
+      const tabs = await this.getAllTabs();
+      if (!tabs.length) {
+        const e = new Error("Spotify is not open");
+        e.displayMessage = "Spotify is not open";
+        throw e;
+      }
+      for (const tab of tabs) {
+        await content.lazyInject(tab.id, "/services/spotify/player.js");
+        await this.callOneTab(tab.id, "move", { direction });
+      }
+    }
+
     async pause() {
       await this.initTab("/services/spotify/player.js");
       await this.callTab("pause");

--- a/extension/services/youtube/player.js
+++ b/extension/services/youtube/player.js
@@ -18,6 +18,14 @@ this.player = (function() {
     action_unpause() {
       this.action_play();
     }
+
+    action_move({ direction }) {
+      if (direction !== "next") {
+        throw new Error("Unexpected direction");
+      }
+      const button = this.querySelector(".ytp-next-button");
+      button.click();
+    }
   }
 
   Player.register();

--- a/extension/services/youtube/youtube.js
+++ b/extension/services/youtube/youtube.js
@@ -30,6 +30,31 @@ this.services.youtube = (function() {
         await this.callOneTab(tab.id, "pause");
       }
     }
+
+    async move(direction) {
+      if (direction === "previous") {
+        const e = new Error("Cannot move to previous YouTube video");
+        e.displayMessage = `YouTube cannot do "${this.context.utterance}"`;
+        throw e;
+      }
+      let tabs = await this.getAllTabs({ audible: true });
+      if (!tabs.length) {
+        const currentTab = (await browser.tabs.query({ active: true }))[0];
+        console.log("test", currentTab.url, this.baseUrl);
+        if (currentTab.url.startsWith(this.baseUrl)) {
+          tabs = [currentTab];
+        } else {
+          const e = new Error("YouTube is not playing");
+          e.displayMessage = "YouTube is not playing";
+          throw e;
+        }
+      }
+      // FIXME: doing this on all audible tabs is odd, though any situation with multiple tabs here is odd
+      for (const tab of tabs) {
+        await content.lazyInject(tab.id, "/services/youtube/player.js");
+        await this.callOneTab(tab.id, "move", { direction });
+      }
+    }
   }
 
   Object.assign(YouTube, {

--- a/extension/tests/intent-viewer.js
+++ b/extension/tests/intent-viewer.js
@@ -29,6 +29,13 @@ async function init() {
             ? "Slots: <code>" + quote(m.slots) + "</code><br>"
             : ""
         }
+        ${
+          m.parameters && Object.keys(m.parameters).length
+            ? "Parameters: <code>" +
+              quote(JSON.stringify(m.parameters)) +
+              "</code><br>"
+            : ""
+        }
       </section>
       `;
     });
@@ -46,6 +53,13 @@ async function init() {
           ${
             e.slots && Object.keys(e.slots).length
               ? "Slots: <code>" + quote(JSON.stringify(e.slots)) + "</code><br>"
+              : ""
+          }
+          ${
+            e.parameters && Object.keys(e.parameters).length
+              ? "Parameters: <code>" +
+                quote(JSON.stringify(e.parameters)) +
+                "</code><br>"
               : ""
           }
         </section>


### PR DESCRIPTION
Fix #321, add skip/next for Spotify and Youtube (and previous for Spotify)
Fix #354, add static parameters to matches