### PR TITLE
Fix #406, prefer the active tab when a service matches several tabs

### DIFF
--- a/extension/background/serviceList.js
+++ b/extension/background/serviceList.js
@@ -163,10 +163,16 @@ this.serviceList = (function() {
           }),
         };
       }
-      if (activate) {
-        await browser.tabs.update(tabs[0].id, { active: activate });
+      let best = 0;
+      for (let i = 0; i < tabs.length; i++) {
+        if (tabs[i].active) {
+          best = i;
+        }
       }
-      return { created: false, tab: tabs[0] };
+      if (activate) {
+        await browser.tabs.update(tabs[best].id, { active: activate });
+      }
+      return { created: false, tab: tabs[best] };
     }
 
     async getAllTabs(extraQuery) {


### PR DESCRIPTION
As an example, with multiple YouTube tabs open, the active tab should be unpaused instead of just the first tab.