### PR TITLE
Fix #407, do not let unpause pause a YouTube video

### DIFF
--- a/extension/services/youtube/player.js
+++ b/extension/services/youtube/player.js
@@ -1,14 +1,28 @@
-/* globals helpers */
+/* globals helpers, log */
 
 this.player = (function() {
   class Player extends helpers.Runner {
+    isPaused() {
+      const video = this.querySelector("video");
+      return video.paused;
+    }
+
     action_play() {
-      const button = this.querySelector("button.ytp-large-play-button");
+      if (!this.isPaused()) {
+        log.info("Attempting to play a video that is already playing");
+        return;
+      }
+      const button = this.querySelector(
+        "button.ytp-large-play-button[aria-label^='Play']"
+      );
       button.click();
-      console.log("clicked", button);
     }
 
     action_pause() {
+      if (this.isPaused()) {
+        log.info("Attempting to paused a video that is already paused");
+        return;
+      }
       const button = this.querySelector(
         "button.ytp-play-button[aria-label^='Pause']"
       );


### PR DESCRIPTION
The pause/unpause buttons are always present in YouTube and act as toggles. This adds a guard that looks at <video>.paused before clicking them.