### PR TITLE
Fix #443, disallow extension in Private Browsing

### DIFF
--- a/extension/manifest.json.ejs
+++ b/extension/manifest.json.ejs
@@ -19,6 +19,7 @@
       "id": "firefox-voice@mozilla.org"
     }
   },
+  "incognito": "not_allowed",
   "background": {
     "scripts": [
       "util.js",


### PR DESCRIPTION
In new versions of Firefox Nightly this may already be the default, but this makes it explicit.