### PR TITLE
Fix #453, increase timeouts and limit permission checks

### DIFF
--- a/extension/limiter.js
+++ b/extension/limiter.js
@@ -1,0 +1,34 @@
+this.limiter = (function() {
+  const exports = {};
+
+  exports.shouldDisplayWarning = async function(
+    warningName,
+    { times, frequency }
+  ) {
+    if (!(times || frequency)) {
+      throw new Error("Must provide times and/or frequency arguments");
+    }
+    const key = `warning.${warningName}`;
+    const info = (await browser.storage.local.get(key))[key];
+    if (!info) {
+      // it's never been run before
+      browser.storage.local.set({ [key]: { times: 1, lastTime: Date.now() } });
+      return true;
+    }
+    if (times && info.times >= times) {
+      return false;
+    }
+    if (frequency && Date.now() - info.lastTime < frequency) {
+      return false;
+    }
+    browser.storage.local.set({
+      [key]: {
+        times: info.times + 1,
+        lastTime: Date.now(),
+      },
+    });
+    return true;
+  };
+
+  return exports;
+})();

--- a/extension/manifest.json.ejs
+++ b/extension/manifest.json.ejs
@@ -32,6 +32,7 @@
       "settings.js",
       "js/vendor/fuse.js",
       "browserUtil.js",
+      "limiter.js",
       "background/pageMetadata.js",
       "background/main.js",
       "background/voiceSchema.js",

--- a/extension/services/youtube/youtube.js
+++ b/extension/services/youtube/youtube.js
@@ -1,4 +1,4 @@
-/* globals intents, serviceList, content, util */
+/* globals intents, serviceList, content, util, limiter */
 
 this.services.youtube = (function() {
   const SUPPORTED_URLS = /^https:\/\/www.youtube.com\/watch/i;
@@ -36,8 +36,14 @@ this.services.youtube = (function() {
       if (!SUPPORTED_URLS.test(loadedTab.url)) {
         return;
       }
-      const isAudible = await this.pollTabAudible(this.tab.id, 2000);
-      if (!isAudible) {
+      const isAudible = await this.pollTabAudible(this.tab.id, 3000);
+      if (
+        !isAudible &&
+        (await limiter.shouldDisplayWarning("youtubeAudible", {
+          times: 3,
+          frequency: 1000,
+        }))
+      ) {
         this.context.failedAutoplay(this.tab);
       }
     }


### PR DESCRIPTION
This gives a bit more time before we decide a service is unable to play. It also limits the total number of warnings to 3 for each individual service.