### PR TITLE
Fix #447, rename fancy search to be normal search

### DIFF
--- a/extension/background/intentParser.js
+++ b/extension/background/intentParser.js
@@ -2,7 +2,7 @@
 this.intentParser = (function() {
   const exports = {};
 
-  const DEFAULT_INTENT = "navigation.search";
+  const DEFAULT_INTENT = "search.search";
   const DEFAULT_SLOT = "query";
 
   /*

--- a/extension/background/main.js
+++ b/extension/background/main.js
@@ -49,6 +49,8 @@ this.main = (function() {
     } else if (message.type === "onVoiceShimForward") {
       message.type = "onVoiceShim";
       return browser.runtime.sendMessage(message);
+    } else if (message.type === "focusSearchResults") {
+      return intents.search.focusSearchResults(message);
     } else if (message.type === "voiceShimForward") {
       message.type = "voiceShim";
       if (!recorderTabId) {

--- a/extension/intents/navigation/navigation.js
+++ b/extension/intents/navigation/navigation.js
@@ -19,25 +19,6 @@ this.intents.navigation = (function() {
   });
 
   this.intentRunner.registerIntent({
-    name: "navigation.search",
-    description: "Do a regular (Google) search",
-    examples: ["Search for hiking in Denver", "Look up recipes for fish tacos"],
-    match: `
-    (do a |) (search | query | find | find me | google | look up | lookup | look on | look for) (google | the web | the internet |) (for |) [query] (on the web |)
-    `,
-    async run(context) {
-      const cardData = await searching.ddgEntitySearch(context.slots.query);
-      if (!cardData) {
-        // Default to Google Search
-        const url = searching.googleSearchUrl(context.slots.query, false);
-        await context.createTab({ url });
-      } else {
-        context.showCard(cardData);
-      }
-    },
-  });
-
-  this.intentRunner.registerIntent({
     name: "navigation.bangSearch",
     description:
       "Search a specific service, using their site-specific search page",

--- a/extension/intents/search/queryScript.js
+++ b/extension/intents/search/queryScript.js
@@ -18,6 +18,7 @@ this.queryScript = (function() {
       hasSidebarCard,
       hasCard,
       searchResults,
+      searchUrl: location.href,
     };
   });
 

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -340,3 +340,7 @@ a#lexicon {
   color: #777;
   font-size: 90%;
 }
+
+#search-image {
+  cursor: pointer;
+}

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -78,7 +78,7 @@
             <!-- FIXME: alt="" isn't correct here: -->
             <img id="search-image" style="display: none" alt="" />
             <div id="search-show-next" style="display: none">
-              Say <strong>fancy search next</strong> to view: <br />
+              Say <strong>next result</strong> to view: <br />
               <strong id="search-show-next-title"></strong>
               <span id="search-show-next-domain"></span>
             </div>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -6,6 +6,7 @@ this.popup = (function() {
   let stream;
   let isWaitingForPermission = null;
   let executedIntent = false;
+  let lastSearchUrl;
 
   const { backgroundTabRecorder } = buildSettings;
 
@@ -94,6 +95,12 @@ this.popup = (function() {
           text,
         });
       };
+      ui.onSearchImageClick = async () => {
+        await browser.runtime.sendMessage({
+          type: "focusSearchResults",
+          searchUrl: lastSearchUrl,
+        });
+      };
     };
     recorder.onEnd = json => {
       // Probably superfluous, since this is called in onProcessing:
@@ -148,6 +155,7 @@ this.popup = (function() {
     } else if (message.type === "displayAutoplayFailure") {
       ui.displayAutoplayFailure();
     } else if (message.type === "showSearchResults") {
+      lastSearchUrl = message.searchUrl;
       ui.showSearchResults(message);
     }
   }

--- a/extension/popup/ui.js
+++ b/extension/popup/ui.js
@@ -86,6 +86,10 @@ this.ui = (function() {
     // can be overridden
   };
 
+  exports.onSearchImageClick = function() {
+    // can be overridden
+  };
+
   function listenForText() {
     const textInput = document.getElementById("text-input-field");
     textInput.focus();
@@ -295,11 +299,18 @@ this.ui = (function() {
     }
   };
 
+  function listenForImageClick() {
+    document.querySelector("#search-image").addEventListener("click", () => {
+      exports.onSearchImageClick();
+    });
+  }
+
   init();
   listenForClose();
   listenForSettings();
   listenForBack();
   listenForLexicon();
+  listenForImageClick();
 
   return exports;
 })();


### PR DESCRIPTION
This removes navigation.search, and makes search.search the default intent.

Also fix #448, make the card image clickable (focusing the search results)