### PR TITLE
Fix #156, Clicking inside the doorhanger no longer blocks the user from typing a command

### DIFF
--- a/extension/popup/ui.js
+++ b/extension/popup/ui.js
@@ -94,6 +94,11 @@ this.ui = (function() {
     const textInput = document.getElementById("text-input-field");
     textInput.focus();
     textInput.addEventListener("keyup", detectText);
+    textInput.addEventListener("blur", () => {
+      setTimeout(() => {
+        textInput.focus();
+      }, 0);
+    });
 
     const sendText = document.getElementById("send-text-input");
     sendText.addEventListener("click", processTextQuery);


### PR DESCRIPTION
Fix #156, Clicking inside the doorhanger no longer blocks the user from typing a command.