### PR TITLE
Fix #450, make search results act on a per-tab basis

### DIFF
--- a/extension/content/communicate.js
+++ b/extension/content/communicate.js
@@ -22,7 +22,7 @@ this.communicate = (function() {
       throw new Error(`No handler for ${message.type}`);
     }
     try {
-      return HANDLERS[message.type](message, sender);
+      return Promise.resolve(HANDLERS[message.type](message, sender));
     } catch (e) {
       log.error(`Error in ${message.type} handler: ${e}`, e.stack);
       const response = {

--- a/extension/intents/search/search.js
+++ b/extension/intents/search/search.js
@@ -9,9 +9,12 @@ this.intents.search = (function() {
   let lastImage = null;
   let _searchTabId;
   const START_URL = "https://www.google.com";
-  let lastSearchInfo;
-  let lastSearchIndex;
+  // This is a popup search result that isn't associated with a tab (because it had a card):
+  let popupSearchInfo;
+  // This is the most recent tab that was interacted with (e.g., I search in tab A, search in tab B, switch to tab A, get next result, switch to tab C, then say next result; tab A should get updated):
   let lastTabId;
+  // These store per-tab search results; tabDataMap handles cleaning up results when a tab is closed:
+  const tabSearchResults = new browserUtil.TabDataMap();
 
   async function openSearchTab() {
     if (closeTabTimeout) {
@@ -64,6 +67,24 @@ this.intents.search = (function() {
     await content.lazyInject(tabId, "/intents/search/queryScript.js");
   }
 
+  /** Returns the popupSearchInfo if it's available, otherwise the active tab's searchInfo,
+   * otherwise the results for lastTabId, and otherwise null
+   */
+  async function getSearchInfo() {
+    if (popupSearchInfo) {
+      return { tabId: null, searchInfo: popupSearchInfo };
+    }
+    const activeTab = await browserUtil.activeTab();
+    const searchInfo = tabSearchResults.get(activeTab.id);
+    if (searchInfo) {
+      return { tabId: activeTab.id, searchInfo };
+    }
+    if (lastTabId) {
+      return { tabId: lastTabId, searchInfo: tabSearchResults.get(lastTabId) };
+    }
+    return { tabId: null, searchInfo: null };
+  }
+
   async function callScript(message) {
     return browser.tabs.sendMessage(_searchTabId, message);
   }
@@ -87,11 +108,8 @@ this.intents.search = (function() {
       }
       lastImage = card.src;
       const response = await browser.runtime.sendMessage({
-        type: "showSearchResults",
+        type: "refreshSearchCard",
         card,
-        searchResults: lastSearchInfo.searchResults,
-        searchUrl: lastSearchInfo.searchUrl,
-        index: -1,
       });
       if (!response) {
         // There's no listener
@@ -123,14 +141,14 @@ this.intents.search = (function() {
     `,
     async run(context) {
       stopCardPoll();
+      // An old popup-only search result is no longer valid once a new search is made:
+      popupSearchInfo = null;
       await performSearch(context.slots.query);
       const searchInfo = await callScript({ type: "searchResultInfo" });
-      lastSearchInfo = searchInfo;
-      lastTabId = undefined;
       if (searchInfo.hasCard) {
         const card = await callScript({ type: "cardImage" });
         context.keepPopup();
-        lastSearchIndex = -1;
+        searchInfo.index = -1;
         await browser.runtime.sendMessage({
           type: "showSearchResults",
           card,
@@ -141,9 +159,11 @@ this.intents.search = (function() {
         if (card.hasWidget) {
           pollForCard();
         }
+        lastTabId = undefined;
+        popupSearchInfo = searchInfo;
       } else {
         context.keepPopup();
-        lastSearchIndex = 0;
+        searchInfo.index = 0;
         await browser.runtime.sendMessage({
           type: "showSearchResults",
           searchResults: searchInfo.searchResults,
@@ -154,6 +174,7 @@ this.intents.search = (function() {
           url: searchInfo.searchResults[0].url,
         });
         lastTabId = tab.id;
+        tabSearchResults.set(tab.id, searchInfo);
       }
     },
   });
@@ -167,30 +188,35 @@ this.intents.search = (function() {
     `,
     async run(context) {
       stopCardPoll();
-      if (!lastSearchInfo) {
+      const { tabId, searchInfo } = await getSearchInfo();
+      if (!searchInfo) {
         const e = new Error("No search made");
         e.displayMessage = "You haven't made a search";
         throw e;
       }
-      if (lastSearchIndex >= lastSearchInfo.searchResults.length - 1) {
+      if (searchInfo.index >= searchInfo.searchResults.length - 1) {
         const tabId = await openSearchTab();
         await context.makeTabActive(tabId);
         return;
       }
-      lastSearchIndex++;
-      const item = lastSearchInfo.searchResults[lastSearchIndex];
+      searchInfo.index++;
+      const item = searchInfo.searchResults[searchInfo.index];
       await browser.runtime.sendMessage({
         type: "showSearchResults",
-        searchResults: lastSearchInfo.searchResults,
-        searchUrl: lastSearchInfo.searchUrl,
-        index: lastSearchIndex,
+        searchResults: searchInfo.searchResults,
+        searchUrl: searchInfo.searchUrl,
+        index: searchInfo.index,
       });
-      if (!lastTabId) {
-        const tab = await browser.tabs.create({ url: item.url, active: true });
+      if (!tabId) {
+        const tab = await context.createTab({ url: item.url });
         // eslint-disable-next-line require-atomic-updates
         lastTabId = tab.id;
+        popupSearchInfo = null;
+        tabSearchResults.set(tab.id, searchInfo);
       } else {
-        await context.makeTabActive(lastTabId);
+        lastTabId = tabId;
+        await context.makeTabActive(tabId);
+        await browser.tabs.update(tabId, { url: item.url });
       }
     },
   });
@@ -204,8 +230,18 @@ this.intents.search = (function() {
     `,
     async run(context) {
       stopCardPoll();
-      const tabId = await openSearchTab();
-      await context.makeTabActive(tabId);
+      const { searchInfo } = await getSearchInfo();
+      if (!searchInfo) {
+        const e = new Error("Show search command without a past search");
+        e.displayMessage = "There is no search to show";
+        throw e;
+      }
+      const searchTabId = await openSearchTab();
+      const searchTab = await browser.tabs.get(searchTabId);
+      if (searchTab.url !== searchInfo.searchUrl) {
+        await browser.tabs.update(searchTabId, { url: searchInfo.url });
+      }
+      await context.makeTabActive(searchTabId);
     },
   });
 

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -158,6 +158,12 @@ this.popup = (function() {
       lastSearchUrl = message.searchUrl;
       ui.showSearchResults(message);
       return Promise.resolve(true);
+    } else if (message.type === "refreshSearchCard") {
+      if (!message.card) {
+        throw new Error(".card propoerty missing on refreshSearchCard message");
+      }
+      ui.showSearchCard(message.card);
+      return Promise.resolve(true);
     }
     return undefined;
   }

--- a/extension/popup/ui.js
+++ b/extension/popup/ui.js
@@ -279,14 +279,7 @@ this.ui = (function() {
   exports.showSearchResults = function({ card, searchResults, index }) {
     exports.setState("searchResults");
     if (card) {
-      const image = document.querySelector("#search-image");
-      image.style.display = "";
-      image.height = card.height;
-      image.width = card.width;
-      image.src = card.src;
-      const container = document.querySelector("#popup");
-      container.style.minWidth = card.width + "px";
-      container.style.minHeight = card.height + 150 + "px";
+      exports.showSearchCard(card);
     }
     const next = searchResults[index + 1];
     if (next) {
@@ -297,6 +290,17 @@ this.ui = (function() {
         next.url
       ).hostname;
     }
+  };
+
+  exports.showSearchCard = function(card) {
+    const image = document.querySelector("#search-image");
+    image.style.display = "";
+    image.height = card.height;
+    image.width = card.width;
+    image.src = card.src;
+    const container = document.querySelector("#popup");
+    container.style.minWidth = card.width + "px";
+    container.style.minHeight = card.height + 150 + "px";
   };
 
   function listenForImageClick() {


### PR DESCRIPTION
This keeps track of multiple search results, so that next result can operate on the current tab, and show results will reload the search that led to the active or most recent tab.

Also fixes #449.