### PR TITLE
Refine intent matches

### DIFF
--- a/extension/background/intentParser.js
+++ b/extension/background/intentParser.js
@@ -11,6 +11,12 @@ this.intentParser = (function() {
     "plain text (alt|text) [slot]"
 
   Spaces separate words, but spaces don't matter too much. Slots are all wildcards.
+
+  You can use `[slot:slotType]` to create a slot that must be of a certain types (types are in ENTITY_MAP)
+
+  You can use `[parameter=value]` to set a parameter on any matches for this one item. This does not capture anything.
+
+  You can use `noun{s}` to match both `noun` and `nouns`.
   */
 
   const ENTITY_TYPES = {
@@ -93,6 +99,8 @@ this.intentParser = (function() {
           regex += " " + words;
         }
       }
+      // Implements the {s} optional strings:
+      regex = regex.replace(/\{(.*?)\}/g, "(?:$1)?");
       return { slots, parameters, regex };
     }
 
@@ -216,9 +224,10 @@ this.intentParser = (function() {
 
   exports.parse = function parse(text, disableFallback = false) {
     text = text.trim();
+    // Normalize whitespace, so there's always just one space between words:
     text = text.replace(/\s\s+/g, " ");
-    text = text.toLowerCase();
-    text = text.replace(/[^a-z0-9 ']\B/gi, "");
+    // Removes punctuation at the end of words, like "this, and that.":
+    text = text.replace(/[.,;!?]\B/g, "");
     let bestMatch;
     let bestChars;
     for (const name of INTENT_NAMES) {

--- a/extension/background/intentRunner.js
+++ b/extension/background/intentRunner.js
@@ -207,7 +207,8 @@ this.intentRunner = (function() {
       });
       if (intent.examples) {
         intent.examples = intent.examples.map(e => {
-          const parsed = intentParser.parse(e, true) || {
+          const toMatch = e.replace(/^test:/, "").replace(/[()]/g, "");
+          const parsed = intentParser.parse(toMatch, true) || {
             name: "NO MATCH",
             slots: {},
           };

--- a/extension/intents/aboutPage/aboutPage.js
+++ b/extension/intents/aboutPage/aboutPage.js
@@ -45,10 +45,10 @@ intents.aboutPage = (function() {
       "This will try to find comments for the current page, searching Reddit and Hacker News, showing forums in order of the number of comments",
     examples: ["Comments on this page?"],
     match: `
-    (show | open |) comments on (this |) (page | tab | article)
-    (show | open |) what are people (saying | talking | commenting) about (this |) (page | tab | article)
-    (show | open |) comments (for | on) (this |) (page | tab | article)
-    (show | open |) comments
+    (show | open |) comment{s} on (this |) (page | tab | article) (to me | for me |)
+    (show | open |) what are people (saying | talking | commenting) about (this |) (page | tab | article) (to me | for me |)
+    (show | open |) comments (for | on) (this |) (page | tab | article) (to me | for me |)
+    (show | open |) comments (to me | for me |)
     `,
     async run(context) {
       const activeTab = await context.activeTab();
@@ -81,8 +81,8 @@ intents.aboutPage = (function() {
     name: "aboutPage.changeComments",
     description: `If you've used "show comments on this page" and there were multiple forums or pages, this will show the next (or previous) comment forum`,
     match: `
-    next (comments | comment) [move=next]
-    previous (comments | comment) [move=previous]
+    next comment{s} [move=next]
+    previous comment{s} [move=previous]
     `,
     async run(context) {
       const activeTab = await context.activeTab();

--- a/extension/intents/bookmarks/bookmarks.js
+++ b/extension/intents/bookmarks/bookmarks.js
@@ -7,12 +7,12 @@ this.intents.bookmarks = (function() {
       "This will search all your bookmarks for the given query, and open what appears to be the best match. Only title and URL are searched",
     examples: ["Open news bookmark"],
     match: `
-    open [query] bookmark in (this | current |) tab [tab=this]
-    open bookmark [query] in (this | current |) tab [tab=this]
+    open [query] bookmark (for me |) in (this | current |) tab (for me |) [tab=this]
+    open bookmark [query] (for me |) in (this | current |) tab (for me |) [tab=this]
     open [query] bookmark in new (tab |)
     open bookmark [query] in new (tab |)
-    open [query] bookmark
-    open bookmark [query]
+    open [query] bookmark (for me|)
+    open bookmark [query] (for me|)
     `,
     async run(context) {
       const bookmarks = await browser.bookmarks.search({});

--- a/extension/intents/find/find.js
+++ b/extension/intents/find/find.js
@@ -5,10 +5,13 @@ this.intents.find = (function() {
     name: "find.find",
     description:
       "Find the open tab that matches the query (searching the title, URL, and page content), and make that tab (and window) active",
-    examples: ["Find calendar tab"],
+    examples: ["Find calendar tab", "test:go to my calendar"],
     match: `
     (find | bring me to) (my | the |) [query] (tab |)
+    (find | open | focus | show) tab [query]
     go (to | to the |) [query] tab
+    go to my [query]
+    focus [query] (tab |)
     `,
     async run(context) {
       const query = context.slots.query;

--- a/extension/intents/music/music.js
+++ b/extension/intents/music/music.js
@@ -71,11 +71,12 @@ this.intents.music = (function() {
     examples: ["Play Green Day"],
     match: `
     play [query] on [service:musicServiceName]
-    play video [query] [service=youtube]
-    play [query] video [service=youtube]
+    play video{s} [query] [service=youtube]
+    play [query] video{s} [service=youtube]
     play [query]
-    (do a |) (search on | query on | lookup on | look up on | look on | look in | look up in | lookup in) (my |) [service:musicServiceName] (for | for the |) [query]
+    (do a |) (search | query | look up| look | look up | lookup) (on | in |) (my |) [service:musicServiceName] (for | for the |) [query]
     (do a |) (search | query ) my [service:musicServiceName] (for | for the |) [query]
+    (do a |) (search | query ) (on |) [service:musicServiceName] (for | for the) [query]
     (do a |) (search | query | find | find me | look up | lookup | look on | look for) (my | on | for | in |) (the |) [query] (on | in) [service:musicServiceName]
     `,
     async run(context) {
@@ -113,7 +114,7 @@ this.intents.music = (function() {
     name: "music.unpause",
     description:
       "Unpause one service, the current tab, or the detected service",
-    examples: ["Unpause", "continue music", "play music"],
+    examples: ["Unpause", "continue music", "play music", "test:play spotify"],
     match: `
     (unpause | continue | play) video [service=youtube]
     (unpause | continue | play) [service:musicServiceName]
@@ -132,13 +133,9 @@ this.intents.music = (function() {
       "Focus the tab of a specific or auto-detected service, maybe opening a tab if none is already open",
     examples: ["Open music"],
     match: `
-    (open | show | focus) video [service=youtube]
-    open [service:musicServiceName]
-    show [service:musicServiceName]
-    focus [service:musicServiceName]
-    open music
-    show music
-    focus music
+    (open | show | focus) (my | the |) video (for me |) [service=youtube]
+    (open | show | focus) [service:musicServiceName] (for me|)
+    (open | show | focus) music
     `,
     async run(context) {
       const service = await getService(context);
@@ -158,7 +155,7 @@ this.intents.music = (function() {
     next (song | track |)             [direction=next]
     play previous (song | track |)    [direction=back]
     previous (song | track |)         [direction=back]
-    skip (song | track |)             [direction=next]
+    (skip | forward) (song | track |) [direction=next]
     `,
     async run(context) {
       const service = await getService(context, { lookAtCurrentTab: true });

--- a/extension/intents/muting/muting.js
+++ b/extension/intents/muting/muting.js
@@ -11,10 +11,10 @@ this.intents.muting = (function() {
       "Mute all audible tabs (new tabs or silent tabs are not muted); does not pause any media, only mute the sound",
     examples: ["mute (all tabs)"],
     match: `
-    (mute | turn off) (whatever is |) (playing | all) (the |) (music | audio | sound | everything | tab | tabs)
+    (mute | turn off) (whatever is |) (playing | all |) (the |) (music | audio | sound | everything | tab{s}) (for me |)
     mute
-    quiet
-    shut up
+    quiet (tabs{s} |) (for me |)
+    shut up (tab{s} |) (for me |)
     `,
     async run(desc) {
       const stoppedReading = await intents.read.stopReading();
@@ -44,7 +44,7 @@ this.intents.muting = (function() {
     name: "mute.unmute",
     description: "Unmute all tabs",
     match: `
-    unmute
+    unmute (tab{s} |) (for me |)
     `,
     async run(desc) {
       const mutedTabs = await browser.tabs.query({ audible: false });

--- a/extension/intents/navigation/navigation.js
+++ b/extension/intents/navigation/navigation.js
@@ -23,12 +23,11 @@ this.intents.navigation = (function() {
     description:
       "Search a specific service, using their site-specific search page",
     match: `
-    google images (of |) [query] [service=images]
-    search images (for |) [query] [service=images]
-    images of [query] [service=images]
-    (do a |) (search | search on | query on | lookup on | look up on | look on | look in | look up in | lookup in) (my |) [service:serviceName] (for | for the |) [query]
-    (do a |) (search | query ) my [service:serviceName] (for | for the |) [query]
-    (do a |) (search | query | find | find me | look up | lookup | look on | look for) (my | on | for | in |) (the |) [query] (on | in) [service:serviceName]
+    google images (of | for |) [query] [service=images]
+    images (of | for) [query] [service=images]
+    (do a |) (search | search on | query on | lookup on | look up on | look on | look in | look up in | lookup in) (my |) [service:serviceName] (for | for the |) [query] (for me |)
+    (do a |) (search | query ) my [service:serviceName] (for | for the |) [query] (for me|)
+    (do a |) (search | query | find | find me | look up | lookup | look on | look for) (my | on | for | in |) (the |) [query] (on | in) [service:serviceName] (for me |)
     `,
     examples: [
       "Search my Gmail for tickets to Hamilton",
@@ -36,6 +35,7 @@ this.intents.navigation = (function() {
       "Search CSS grid on MDN",
       "Look up Hamilton in Gmail",
       "Images of sparrows",
+      "test:search google images of sparrows for me",
     ],
     async run(context) {
       const service = context.slots.service || context.parameters.service;
@@ -58,9 +58,9 @@ this.intents.navigation = (function() {
     name: "navigation.translate",
     description: "Translate the given page to English, using Google Translate",
     match: `
-    translate (this |) (page | tab | article | site | this) (to english |)
+    translate (this |) (page | tab | article | site |) (to english |) (for me |)
     `,
-    examples: ["Translate this page"],
+    examples: ["Translate this page", "test:translate"],
     async run(context) {
       const tab = await context.activeTab();
       const translation = `https://translate.google.com/translate?hl=&sl=auto&tl=en&u=${encodeURIComponent(
@@ -75,7 +75,7 @@ this.intents.navigation = (function() {
     description:
       "Translate whatever text is selected to English, using Google Translate",
     match: `
-    translate (this |) selection (to english |)
+    translate (this |) selection (to english |) (for me |)
     `,
     examples: ["Translate selection"],
     async run(context) {

--- a/extension/intents/notes/notes.js
+++ b/extension/intents/notes/notes.js
@@ -26,7 +26,8 @@ this.intents.notes = (function() {
       "Indicate where note should be written, both the tab and the element on the tab where text will go",
     examples: ["Write notes here"],
     match: `
-    (write | add | make) (notes |) (here | this page | this tab)
+    (add | make) note{s} (here | this page | this tab) (for me |)
+    write (note{s} |) (here | this page | this tab) (for me |)
     `,
     async run(context) {
       const activeTab = await context.activeTab();
@@ -49,7 +50,7 @@ this.intents.notes = (function() {
     description: "Add to the note with the link and title of the current tab",
     examples: ["Make note of this page"],
     match: `
-    (make | add | write |) note (of | about |) (this |) (page | tab | link)
+    (make | add | write |) note{s} (of | about |) (this |) (page | tab | link) (for me |)
     `,
     async run(context) {
       await checkHasTab();
@@ -72,7 +73,7 @@ this.intents.notes = (function() {
     description: "Add to the note with the given text",
     examples: ["Add note stuff to remember"],
     match: `
-    (make | add | write) note (about |) [text]
+    (make | add | write) note{s} (about |) [text] (for me |)
     `,
     async run(context) {
       await checkHasTab();
@@ -94,7 +95,7 @@ this.intents.notes = (function() {
       "Focus the tab previously indicated as being the place to write notes",
     examples: ["Show notes"],
     match: `
-    (show | focus | activate | read) (the |) notes
+    (show | focus | activate | read) (the |) note{s} (for me |)
     `,
     async run(context) {
       if (!writingTabId) {

--- a/extension/intents/read/read.js
+++ b/extension/intents/read/read.js
@@ -43,7 +43,7 @@ this.intents.read = (function() {
       "Narrate the given page. This puts the page into Reader Mode (failing if it can't) and starts narration",
     examples: ["Read this page"],
     match: `
-    read (this |) (tab | page |)
+    read (this |) (tab | page |) (for me | to me |)
     `,
     async run(context) {
       const activeTab = await context.activeTab();
@@ -84,7 +84,7 @@ this.intents.read = (function() {
     description: "Stop reading/narrating the current tab",
     examples: ["Stop reading"],
     match: `
-    stop reading (this |) (tab | page |)
+    stop reading (this |) (tab | page |) (to me | for me |)
     `,
     async run(context) {
       const activeTab = await context.activeTab();

--- a/extension/intents/search/search.js
+++ b/extension/intents/search/search.js
@@ -119,7 +119,7 @@ this.intents.search = (function() {
     description:
       "Experimental search interface; this does all searches in a special pinned tab, and if the search results in a card then a screenshot of the card is displayed in the popup. If there's no card, then the first search result is opened in a new tab.",
     match: `
-    (do a |) (search | query | find | find me | google | look up | lookup | look on | look for) (google | the web | the internet |) (for |) [query] (on the web |)
+    (do a |) (search | query | find | find me | google | look up | lookup | look on | look for) (google | the web | the internet |) (for |) [query] (on the web |) (for me |)
     `,
     async run(context) {
       stopCardPoll();
@@ -162,8 +162,9 @@ this.intents.search = (function() {
     name: "search.next",
     description:
       "If you've done a search then this will display the next search result. If the last search had a card, and no search result was opened, then this will open a new tab with the first search result.",
+    examples: ["test:next search item"],
     match: `
-    (search |) next (search |) (result | item | page | article |)
+    (search |) next (search |) (result{s} | item{s} | page | article |)
     `,
     async run(context) {
       stopCardPoll();
@@ -198,9 +199,10 @@ this.intents.search = (function() {
   intentRunner.registerIntent({
     name: "search.show",
     description: "Focuses the special tab used for searching",
+    examples: ["test:open results", "test:show search result"],
     match: `
-    (open | show | focus) search (results |)
-    (open | show | focus) results
+    (open | show | focus) search (result{s} |)
+    (open | show | focus) result{s}
     `,
     async run(context) {
       stopCardPoll();

--- a/extension/intents/self/self.js
+++ b/extension/intents/self/self.js
@@ -2,6 +2,7 @@ this.intents.self = (function() {
   this.intentRunner.registerIntent({
     name: "self.cancelIntent",
     description: "Cancels input, immediately closing the popup",
+    examples: ["test:nevermind"],
     match: `
     cancel
     nevermind
@@ -34,7 +35,7 @@ this.intents.self = (function() {
     name: "self.openOptions",
     description: "Opens the options page",
     match: `
-    (open | open the | voice | firefox voice) (settings | options)
+    (open | open the | voice | firefox voice) (settings | options) (for me |)
     `,
     async run(context) {
       await browser.tabs.create({
@@ -47,7 +48,7 @@ this.intents.self = (function() {
     name: "self.openIntentViewer",
     description: "Opens the intent viewer (probably this page)",
     match: `
-    (show | open) all intents
+    (show | open) all intents (for me |)
     `,
     async run(context) {
       await browser.tabs.create({

--- a/extension/intents/tabs/tabs.js
+++ b/extension/intents/tabs/tabs.js
@@ -4,8 +4,7 @@ this.intents.tabs = (function() {
     description: "Closes the current tab",
     examples: ["close tab"],
     match: `
-    close tab
-    close this tab
+    close (this |) tab (for me |)
     `,
     async run(context) {
       const activeTab = await context.activeTab();
@@ -19,7 +18,8 @@ this.intents.tabs = (function() {
     examples: ["open tab"],
     match: `
     open tab
-    open (a |) (new | blank |) tab
+    open (a |) (new | blank |) tab (for me|)
+    new (blank |) tab
     `,
     async run(context) {
       await context.createTab({ active: true });


### PR DESCRIPTION
This tries to improve and expand on several intent matches. Fixes #495. Fixes #496.

Also adds test: examples, that aren't displayed in the popup, but are used in the intent viewer as tests of a sort.