### PR TITLE
Attempt to fix #520, use .y consistently for judging positions

### DIFF
--- a/extension/intents/search/queryScript.js
+++ b/extension/intents/search/queryScript.js
@@ -7,7 +7,7 @@ this.queryScript = (function() {
 
   function findCards() {
     const topElement = document.querySelector("a > h3");
-    const maxBottom = topElement.getBoundingClientRect().top;
+    const maxBottom = topElement.getBoundingClientRect().y;
     return {
       card: findCardIn(document.querySelector(MAIN_SELECTOR), maxBottom),
       sidebarCard: findCardIn(document.querySelector(SIDEBAR_SELECTOR), null),


### PR DESCRIPTION
This may include more cards, if the position selection was incorrectly filtering out some cards.