### PR TITLE
Fixed typo

### DIFF
--- a/extension/views/lexicon.html.ejs
+++ b/extension/views/lexicon.html.ejs
@@ -72,7 +72,7 @@
             Ask a question
           </div>
           <div class="description">
-            Displays anwser in a card.
+            Displays answer in a card.
           </div>
           <div class="utterance">
             Example


### PR DESCRIPTION
Typo in the "Ask a question" section from the "Lexicon" page #605