### PR TITLE
Fixed typo

### DIFF
--- a/extension/options/optionsView.jsx
+++ b/extension/options/optionsView.jsx
@@ -227,7 +227,7 @@ this.optionsView = (function() {
                 onChange={onUtteranceTelemetryChange}
               />
               <label htmlFor="transcripts-data">
-                Allow Firefox Voice to send anonymized transcipts of your audio
+                Allow Firefox Voice to send anonymized transcripts of your audio
                 request.
               </label>
             </div>


### PR DESCRIPTION
Typo in the "Firefox Voice Data Collection and Use" section from the "Settings" page #594