### PR TITLE
Fix "Supported sites" in the "Search a specific website" lexicon

### DIFF
--- a/extension/views/lexicon.html.ejs
+++ b/extension/views/lexicon.html.ejs
@@ -45,9 +45,11 @@
               <strong>Supported sites:</strong> Gmail, Google Docs, Google
               Calendar, Google Slides, Google Maps, MDN, GoodReads, Spotify,
               Amazon, Wikipedia, Yelp, Twitter, Reddit, Amazon Music, Google
-              Play Music, Pandora, SoundCloud, YouTube, Vimeo, Netflix, Hulu,
-              StubHub, TicketMaster, Instagram, LinkedIn, Quora, Pinterest,
-              Facebook, Stack Exchange, Dictionary, Thesaurus, DuckDuckGo
+              Play Music, Pandora, SoundCloud, YouTube, Vimeo, Netflix, StubHub,
+              TicketMaster, Instagram, LinkedIn, Quora, Pinterest, Facebook,
+              Stack Exchange, Dictionary, Thesaurus, DuckDuckGo, Amazon Maps,
+              DuckDuckGo Images, Google Drive, Google Images, Google Scholar,
+              Google Sheets, Google Translate, OpenStreetMap, TuneIn.
             </div>
           </div>
         </div>


### PR DESCRIPTION
Fix #626