### PR TITLE
Centers the feedback link to the middle of the popup.

### DIFF
--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -101,6 +101,7 @@ body,
 
 #moz-voice-privacy {
   line-height: 20px;
+  margin-right: 32px;
 }
 
 #moz-voice-privacy > a {


### PR DESCRIPTION
Fixes #691