### PR TITLE
Shows minimized or expanded listening view based on voice interaction…

### DIFF
--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -132,6 +132,8 @@ body,
   opacity: 0;
   margin: 0;
   height: 0;
+  position: absolute;
+  top: 0;
 }
 
 #search-results {

--- a/extension/popup/popupView.jsx
+++ b/extension/popup/popupView.jsx
@@ -27,6 +27,7 @@ this.popupView = (function() {
     onInputStarted,
     onSubmitFeedback,
     setMinPopupSize,
+    expandListeningView,
   }) => {
     const [inputValue, setInputValue] = useState(null);
     function savingOnInputStarted(value) {
@@ -62,6 +63,7 @@ this.popupView = (function() {
           onInputStarted={savingOnInputStarted}
           onSubmitFeedback={onSubmitFeedback}
           setMinPopupSize={setMinPopupSize}
+          expandListeningView={expandListeningView}
         />
         <PopupFooter currentView={currentView} showSettings={showSettings} />
       </div>
@@ -168,6 +170,7 @@ this.popupView = (function() {
     onInputStarted,
     onSubmitFeedback,
     setMinPopupSize,
+    expandListeningView,
   }) => {
     const getContent = () => {
       switch (currentView) {
@@ -180,6 +183,7 @@ this.popupView = (function() {
               onClickLexicon={onClickLexicon}
               onInputStarted={onInputStarted}
               onSubmitFeedback={onSubmitFeedback}
+              expandListeningView={expandListeningView}
             />
           );
         case "typing":
@@ -325,11 +329,16 @@ this.popupView = (function() {
     onClickLexicon,
     onInputStarted,
     onSubmitFeedback,
+    expandListeningView,
   }) => {
     return (
       <React.Fragment>
         <TextDisplay displayText={displayText} />
-        <VoiceInput suggestions={suggestions} onClickLexicon={onClickLexicon} />
+        <VoiceInput
+          suggestions={suggestions}
+          onClickLexicon={onClickLexicon}
+          expandListeningView={expandListeningView}
+        />
         <TypingInput onInputStarted={onInputStarted} />
         {lastIntent ? (
           <IntentFeedback
@@ -353,7 +362,7 @@ this.popupView = (function() {
     );
   };
 
-  const VoiceInput = ({ suggestions, onClickLexicon }) => {
+  const VoiceInput = ({ suggestions, onClickLexicon, expandListeningView }) => {
     const onMoreSuggestions = event => {
       if (event) {
         event.preventDefault();
@@ -362,7 +371,7 @@ this.popupView = (function() {
     };
     return (
       <div id="voice-input">
-        {suggestions ? (
+        {suggestions && expandListeningView ? (
           <div id="suggestions">
             <p id="prompt">You can say things like:</p>
             <div id="suggestions-list">

--- a/extension/popup/popupView.jsx
+++ b/extension/popup/popupView.jsx
@@ -340,7 +340,7 @@ this.popupView = (function() {
           expandListeningView={expandListeningView}
         />
         <TypingInput onInputStarted={onInputStarted} />
-        {lastIntent ? (
+        {lastIntent && expandListeningView ? (
           <IntentFeedback
             lastIntent={lastIntent}
             onSubmitFeedback={onSubmitFeedback}


### PR DESCRIPTION
… and number of visits

Fixes #324 

- [x] After trigger the doorhanger opens to a "Listen" state showing only a title, the Zap, settings icon, and link to privacy statement.
- [x] After 3 seconds of no audio activity the doorhanger expands to reveal example utterances and feedback for previous requests.
- [x] The first 5 uses of Firefox Voice after installation should override the above behavior and show the fully expanded doorhanger to suggest things that can be said.
- [ ] When timeout occurs (6 seconds?) the doorhanger should auto close itself (instead of displaying an error).
