### PR TITLE
Prevent onboarding page from being opened multiple times

### DIFF
--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -9,6 +9,7 @@
     <div id="popup-container"></div>
     <script src="../js/vendor/react.production.min.js"></script>
     <script src="../js/vendor/react-dom.production.min.js"></script>
+    <script src="../browserUtil.js"></script>
     <script src="../buildSettings.js"></script>
     <script src="../log.js"></script>
     <script src="../catcherAsyncSetup.js"></script>

--- a/extension/popup/popupController.jsx
+++ b/extension/popup/popupController.jsx
@@ -50,18 +50,14 @@ this.popupController = (function() {
     const init = async () => {
       const userSettings = await settings.getSettings();
       if (!userSettings.collectTranscriptsOptinAnswered) {
-        console.log("Searching for open onboarding tabs...");
+        let onboardingURL = browser.runtime.getURL("/onboarding/onboard.html");
         for (const tab of await browser.tabs.query({
-          url: ["moz-extension://*/onboarding/onboard.html"]
+          url: [onboardingURL]
         })) {
-          console.log("Found an open onboarding tab!");
-          window.close();
-          console.log("Trying to open tab " + tab.id);
-          await browserUtil.makeTabActive(tab);
-          return;
+          await browser.tabs.remove(tab.id);
         }
         browser.tabs.create({
-          url: browser.runtime.getURL("onboarding/onboard.html"),
+          url: onboardingURL,
         });
         window.close();
         return;

--- a/extension/popup/popupController.jsx
+++ b/extension/popup/popupController.jsx
@@ -50,6 +50,16 @@ this.popupController = (function() {
     const init = async () => {
       const userSettings = await settings.getSettings();
       if (!userSettings.collectTranscriptsOptinAnswered) {
+        console.log("Searching for open onboarding tabs...");
+        for (const tab of await browser.tabs.query({
+          url: ["moz-extension://*/onboarding/onboard.html"]
+        })) {
+          console.log("Found an open onboarding tab!");
+          window.close();
+          console.log("Trying to open tab " + tab.id);
+          await browserUtil.makeTabActive(tab);
+          return;
+        }
         browser.tabs.create({
           url: browser.runtime.getURL("onboarding/onboard.html"),
         });


### PR DESCRIPTION
While this code keeps the onboarding page from being opened in multiple tabs, it does not properly switch to an existing tab, despite the call to `browserUtil.makeTabActive()`. My hope is that a reviewer could let me know what I'm doing wrong. Thank you.