### PR TITLE
Fix Google redirect on Android

### DIFF
--- a/extension/background/intentRunner.js
+++ b/extension/background/intentRunner.js
@@ -125,12 +125,12 @@ this.intentRunner = (function() {
               return;
             }
             // We no longer need to listen for updates:
-            browser.tabs.onUpdated.removeListener(onUpdated, { tabId: tab.id });
+            browserUtil.onUpdatedRemove(onUpdated, tab.id);
             resolve(tab);
           }
         }
         try {
-          browser.tabs.onUpdated.addListener(onUpdated, { tabId: tab.id });
+          browserUtil.onUpdatedListen(onUpdated, tab.id);
         } catch (e) {
           throw new Error(
             `Error in tabs.onUpdated: ${e}, onUpdated type: ${typeof onUpdated}, args: tabId: ${

--- a/extension/browserUtil.js
+++ b/extension/browserUtil.js
@@ -1,3 +1,5 @@
+/* globals buildSettings */
+
 this.browserUtil = (function() {
   const exports = {};
   exports.activeTab = async function activeTab() {
@@ -101,6 +103,27 @@ this.browserUtil = (function() {
       code: "null",
       runAt: "document_idle",
     });
+  };
+
+  /** Wrappers for browser.tabs.onUpdated to handle Android compatibility */
+  exports.onUpdatedListen = function(callback, tabId) {
+    if (buildSettings.android) {
+      callback.wrappedFunction = (tabId, changeInfo, tab) => {
+        if (tab.id !== tabId) {
+          return null;
+        }
+        return callback(tabId, changeInfo, tab);
+      };
+      return browser.tabs.onUpdated.addListener(callback.wrappedFunction);
+    }
+    return browser.tabs.onUpdated.addListener(callback, { tabId });
+  };
+
+  exports.onUpdatedRemove = function(callback, tabId) {
+    if (buildSettings.android) {
+      return browser.tabs.onUpdated.removeListener(callback.wrappedFunction);
+    }
+    return browser.tabs.onUpdated.removeListener(callback, { tabId });
   };
 
   return exports;

--- a/extension/buildSettings.js.ejs
+++ b/extension/buildSettings.js.ejs
@@ -10,4 +10,5 @@ this.buildSettings = {
   channel: "<%- env.INSTALL_CHANNEL || "unknown" %>",
   sentryDsn: <%= (env.NO_SENTRY && !env.FORCE_SENTRY) ? null : env.SENTRY_DSN || "https://18143ece2d6042ff91ed7678b287a814@sentry.prod.mozaws.net/458" %>,
   openPopupOnStart: <%= !!env.OPEN_POPUP_ON_START %>,
+  android: <%= !!env.ANDROID %>,
 };


### PR DESCRIPTION
The Android extension API doesn't support the tabId specifier on browser.tabs.onUpdated