### PR TITLE
Fix #878, improve scoring to avoid substitutions

### DIFF
--- a/extension/intents/clipboard/clipboard.js
+++ b/extension/intents/clipboard/clipboard.js
@@ -28,7 +28,7 @@ this.intents.clipboard = (function() {
   });
 
   this.intentRunner.registerIntent({
-    name: "nicknames.copyTitle",
+    name: "clipboard.copyTitle",
     description: "Copies the title of the current tab",
     examples: ["Copy tab title"],
     match: `
@@ -42,7 +42,7 @@ this.intents.clipboard = (function() {
   });
 
   this.intentRunner.registerIntent({
-    name: "nicknames.copyRichLink",
+    name: "clipboard.copyRichLink",
     description: "Copies the HTML title and link",
     examples: ["Copy HTML link"],
     match: `
@@ -58,7 +58,7 @@ this.intents.clipboard = (function() {
   });
 
   this.intentRunner.registerIntent({
-    name: "nicknames.copyMarkdownLink",
+    name: "clipboard.copyMarkdownLink",
     description: "Copies the Markdown [title](link)",
     examples: ["Copy Markdown link"],
     match: `
@@ -73,7 +73,7 @@ this.intents.clipboard = (function() {
   });
 
   this.intentRunner.registerIntent({
-    name: "nicknames.copyScreenshot",
+    name: "clipboard.copyScreenshot",
     description: "Copies the screenshot of the visible page",
     examples: ["Copy screenshot"],
     match: `
@@ -87,7 +87,7 @@ this.intents.clipboard = (function() {
   });
 
   this.intentRunner.registerIntent({
-    name: "nicknames.copyFullPageScreenshot",
+    name: "clipboard.copyFullPageScreenshot",
     description: "Copies a full page screenshot",
     examples: ["Copy full page screenshot"],
     match: `
@@ -101,7 +101,7 @@ this.intents.clipboard = (function() {
   });
 
   this.intentRunner.registerIntent({
-    name: "nicknames.copySelection",
+    name: "clipboard.copySelection",
     description: "Copies the selection",
     examples: ["Copy selection"],
     match: `
@@ -113,9 +113,9 @@ this.intents.clipboard = (function() {
   });
 
   this.intentRunner.registerIntent({
-    name: "nicknames.paste",
-    description: "Copies the selection",
-    examples: ["Copy selection"],
+    name: "clipboard.paste",
+    description: "Pastes from the clipboard",
+    examples: ["Paste"],
     match: `
     paste (the |) (selection | clipboard |)
     `,

--- a/extension/intents/navigation/navigation.js
+++ b/extension/intents/navigation/navigation.js
@@ -75,6 +75,7 @@ this.intents.navigation = (function() {
       "Images of sparrows",
       "Find the nearest sushi on maps",
       "test:search google images of sparrows for me",
+      "test:Find website work plan on my Google Drive",
     ],
     async run(context) {
       const service = context.slots.service || context.parameters.service;

--- a/extension/intents/saving/saving.js
+++ b/extension/intents/saving/saving.js
@@ -4,7 +4,7 @@ this.intents.saving = (function() {
   this.intentRunner.registerIntent({
     name: "saving.save",
     description: "Saves the current page as HTML",
-    examples: ["Save"],
+    examples: ["Save page", "Save page as an example"],
     match: `
     (save | download) (this | active |) (page | html) (as html |)
     (save | download) (this | active |) (page | html) as [name]

--- a/extension/intents/tabs/tabs.js
+++ b/extension/intents/tabs/tabs.js
@@ -126,7 +126,7 @@ this.intents.tabs = (function() {
     examples: ["open tab", "test:open top for me", "test:open the tab"],
     match: `
     open tab
-    (open | launch) (a |) (new | blank |) tab (for me|)
+    (open | launch) (a | the |) (new | blank |) tab (for me|)
     new (blank |) tab
     `,
     async run(context) {


### PR DESCRIPTION
Some substitutions were being preferred because they decreased the slot characters, which does not really count as being a better match.

Also individual word substitutions were entirely broken, and only simultaneously doing all substitutions was working.

Fix a few errors in intent descriptions, some bad example names, and some incorrect intent names.