### PR TITLE
Fix #849, remove TLDs from lucky searches

### DIFF
--- a/extension/searching.js
+++ b/extension/searching.js
@@ -2,9 +2,13 @@
 
 this.searching = (function() {
   const exports = {};
+  const luckySearchRemovals = /\.(com|net|org)$/i;
 
   exports.googleSearchUrl = function(query, feelingLucky = false) {
     const searchUrl = new URL("https://www.google.com/search");
+    if (feelingLucky) {
+      query = query.replace(luckySearchRemovals, "");
+    }
     searchUrl.searchParams.set("q", query);
     if (feelingLucky) {
       searchUrl.searchParams.set("btnI", "");


### PR DESCRIPTION
For unknown reasons, Google refuses to do an I'm Lucky search when the search term is a domain name.