### PR TITLE
Delete "copy markdown link" extra semicolon

### DIFF
--- a/extension/intents/clipboard/contentScript.js
+++ b/extension/intents/clipboard/contentScript.js
@@ -100,7 +100,7 @@ this.contentScript = (function() {
 
   types.copyMarkdownLink = function() {
     const m = meta();
-    return `[${m.title}](${m.canonical || m.url});`;
+    return `[${m.title}](${m.canonical || m.url})`;
   };
 
   types.copySelection = function() {


### PR DESCRIPTION
Fix #956 