### PR TITLE
Get more information for #1023

### DIFF
--- a/extension/intents/search/search.js
+++ b/extension/intents/search/search.js
@@ -133,7 +133,14 @@ async function callScript(message) {
       `Attempt to send message ${message.type} to missing search tab`
     );
   }
-  return browser.tabs.sendMessage(_searchTabId, message);
+  try {
+    const result = await browser.tabs.sendMessage(_searchTabId, message);
+    return result;
+  } catch (e) {
+    e.searchTabId = _searchTabId;
+    e.sendMessageBody = message;
+    throw e;
+  }
 }
 
 let cardPollTimeout;


### PR DESCRIPTION
We're seeing errors about tabs.sendMessage, even though we have a guard around the call. This should add some more information to Sentry to understand the error.