### PR TITLE
Fix #1021, only give error message when there's an error

### DIFF
--- a/extension/background/main.js
+++ b/extension/background/main.js
@@ -181,10 +181,10 @@ async function openRecordingTab() {
 }
 
 async function zeroVolumeError() {
-  const exc = new Error("zeroVolumeError with no recorder tab");
-  log.error(exc.message);
-  catcher.capture(exc);
   if (!recorderTabId) {
+    const exc = new Error("zeroVolumeError with no recorder tab");
+    log.error(exc.message);
+    catcher.capture(exc);
     throw exc;
   }
   await browserUtil.makeTabActive(recorderTabId);


### PR DESCRIPTION
The logic for reporting a zeroVolumeError returned it for all cases, not just when it actually happened.