### PR TITLE
Fix #1071, keep recorder from working after being cancelled

### DIFF
--- a/extension/popup/voice.js
+++ b/extension/popup/voice.js
@@ -58,13 +58,19 @@ export class Recorder {
     };
     // FIXME: this is a bad pattern, but all I got for now...
     vad.events.onProcessing = () => {
-      this.onProcessing();
+      if (!this.cancelled) {
+        this.onProcessing();
+      }
     };
     vad.events.onNoVoice = () => {
-      this.onNoVoice();
+      if (!this.cancelled) {
+        this.onNoVoice();
+      }
     };
     vad.events.onStartVoice = () => {
-      this.onStartVoice();
+      if (!this.cancelled) {
+        this.onStartVoice();
+      }
     };
     // connect stream to our recorder
     this.sourceNode.connect(this.scriptprocessor);


### PR DESCRIPTION
The recorder still runs in the background, even after the media stream is closed. As a result events can still keep coming in, even though we've cancelled the recorder. There was logic in the shim that avoided this, but needed to be recreated for local recording