### PR TITLE
First quick attempt at generating the language of commands accepted by Firefox Voice

### DIFF
--- a/bin/list-all-intent-matches.js
+++ b/bin/list-all-intent-matches.js
@@ -1,0 +1,79 @@
+const toml = require("toml");
+const path = require("path");
+const fs = require("fs");
+const glob = require("glob");
+const { extensionDir, writeFile } = require("./script-utils.js");
+
+const INTENT_DIR = path.join(extensionDir, "intents");
+
+function splitPhraseLines(string) {
+  if (typeof string !== "string") {
+    throw new Error(`Bad input: ${string}`);
+  }
+  const result = [];
+  for (let line of string.split("\n")) {
+    line = line.trim();
+    if (!line || line.startsWith("#") || line.startsWith("//")) {
+      continue;
+    }
+    result.push(line);
+  }
+  return result;
+}
+
+function _isAltWord(string) {
+  return /\{[^}]+\}/.test(string);
+}
+
+function _altWords(string) {
+  const bit = /\{([^}]+)\}/.exec(string)[1];
+  const baseWord = string.replace(/\{[^}]+\}/, "");
+  const altWord = string.replace(/\{[^}]\}/, bit);
+  return [baseWord, altWord];
+}
+
+const metadata = {};
+
+for (const filename of glob.sync(INTENT_DIR + "/**/*.toml")) {
+  const intentName = path.basename(filename, ".toml");
+  let data;
+  try {
+    data = toml.parse(fs.readFileSync(filename));
+  } catch (e) {
+    console.warn("Error:", e, "in file:", filename);
+    continue;
+  }
+  if (Object.keys(data).length > 1 || !data[intentName]) {
+    console.error(
+      `File ${filename} should only contain the top-level key ${intentName} (not ${Object.keys(
+        data
+      )})`
+    );
+    process.exit(1);
+  }
+  if (metadata[intentName]) {
+    throw new Error(`Unexpected existing key for ${intentName}`);
+  }
+  Object.assign(metadata, data);
+}
+
+for (const intent of Object.keys(metadata)) {
+  for (const command of Object.keys(metadata[intent])) {
+    const matcher = metadata[intent][command]["match"];
+    for (const line of splitPhraseLines(matcher)) {
+      let removedParams = line.replace(/\[\w+=\w+\]/g, "")
+      // convert "base{alternative}" syntax to regex
+      if (_isAltWord(removedParams)) {
+        removedParams = removedParams.replace(/\{([^}]+)\}/g, "($1)?");
+      }
+      // escape literal periods
+      removedParams = removedParams.replace(".", "\\.");
+      // ignore slots for now
+      if (!removedParams.includes("[")) {
+        console.log(removedParams);
+      } else {
+        console.error("Ignoring a match in " + intent + "." + command + " because it has slots. (" + line + ")");
+      }
+    }
+  }
+}


### PR DESCRIPTION
While thinking about how to create specialized language models to recognize Firefox Voice commands, I modified `bin/parse-intent-toml.js` to go over all match lines of all intents, do a bit of clean-up to make them look like regexes when possible, and print them. Then I used [regex-generate/regenerate](https://github.com/regex-generate/regenerate) to generate the language of accepted strings for each line using this command:

```
$ node bin/list-all-intent-matches.js | tr '\n' '\0' | xargs -0 -n1 gen_re.exe gen >> all_phrases_without_slots.txt
Ignoring a match in bookmarks.open because it has slots. (open [query] bookmark (for me |) in (this | current |) tab (for me |) [tab=this])
Ignoring a match in bookmarks.open because it has slots. (open bookmark [query] (for me |) in (this | current |) tab (for me |) [tab=this])
Ignoring a match in bookmarks.open because it has slots. (open [query] bookmark in new (tab |))
Ignoring a match in bookmarks.open because it has slots. (open bookmark [query] in new (tab |))
Ignoring a match in bookmarks.open because it has slots. (open [query] bookmark (for me|))
Ignoring a match in bookmarks.open because it has slots. (open bookmark [query] (for me|))
Ignoring a match in find.find because it has slots. ((find | bring me to | bring up | switch to) (my | the |) [query] (tab |))
Ignoring a match in find.find because it has slots. ((find | open | focus | show | switch to) tab [query])
Ignoring a match in find.find because it has slots. (go (to | to the |) [query] tab)
Ignoring a match in find.find because it has slots. (go to my [query])
Ignoring a match in find.find because it has slots. (focus [query] (tab |))
Ignoring a match in forms.dictate because it has slots. ((enter | type | write) (text |) [text] (in | into |) (page | field | input | textarea | document | element |))
Ignoring a match in forms.focusField because it has slots. (focus (field | input | text | textarea | element |) (named | with name | labeled | with label |) [label] (field | input | element |))
Ignoring a match in music.focus because it has slots. ((open | show | focus) [service:musicServiceName] (for me|))
Ignoring a match in music.pause because it has slots. (pause [service:musicServiceName])
Ignoring a match in music.play because it has slots. (play [query] (on | in) [service:musicServiceName])
Ignoring a match in music.play because it has slots. (play video{s} [query] [service=youtube])
Ignoring a match in music.play because it has slots. (play [query] video{s} [service=youtube])
Ignoring a match in music.play because it has slots. (play [query])
Ignoring a match in music.play because it has slots. ((do a |) (search | query | look up| look | look up | lookup) (on | in |) (my |) [service:musicServiceName] (for | for the |) [query])
Ignoring a match in music.play because it has slots. ((do a |) (search | query ) my [service:musicServiceName] (for | for the |) [query])
Ignoring a match in music.play because it has slots. ((do a |) (search | query ) (on |) [service:musicServiceName] (for | for the) [query])
Ignoring a match in music.play because it has slots. ((do a |) (search | query | find | find me | look up | lookup | look on | look for) (my | on | for | in |) (the |) [query] (on | in) [service:musicServiceName])
Ignoring a match in music.unpause because it has slots. ((unpause | continue | play | resume) [service:musicServiceName])
Ignoring a match in navigation.bangSearch because it has slots. (google images (of | for |) [query] [service=images])
Ignoring a match in navigation.bangSearch because it has slots. (images (of | for) [query] [service=images])
Ignoring a match in navigation.bangSearch because it has slots. ((do a |) (search | search on | query on | lookup on | look up on | look on | look in | look up in | lookup in) (my |) [service:serviceName] (for | for the |) [query] (for me |))
Ignoring a match in navigation.bangSearch because it has slots. ((do a |) (search | query ) my [service:serviceName] (for | for the |) [query] (for me|))
Ignoring a match in navigation.bangSearch because it has slots. ((do a |) (search | query | find | find me | look up | lookup | look on | look for) (my | on | for | in |) (the |) [query] (on | in) [service:serviceName] (for me |))
Ignoring a match in navigation.navigate because it has slots. ((bring me | take me | go | navigate | show me | open) (to | find |) (page |) [query])
Ignoring a match in navigation.translate because it has slots. (translate (this |) (web page | webpage | page | tab | article | site |) to [language:lang] (for me |))
Ignoring a match in navigation.translateSelection because it has slots. (translate (this | the |) (selection | selected text) to [language:lang] (for me |))
Ignoring a match in navigation.followLink because it has slots. ((follow | click | click on | openlink) (link |) [query])
Ignoring a match in navigation.followLink because it has slots. ((open | go to) link [query])
Ignoring a match in nicknames.name because it has slots. ((name | nickname | shortcut | call) (that | it | last) [name])
Ignoring a match in nicknames.name because it has slots. (give (that |) (the |) (name | nickname | shortcut) [name])
Ignoring a match in nicknames.name because it has slots. (give (the |) (name | nickname | shortcut) [name] to (that | it | last))
Ignoring a match in nicknames.nameLast because it has slots. ((name | nickname | call | shortcut) last [number:smallNumber] [name])
Ignoring a match in nicknames.nameLast because it has slots. (give (the |) last [number:smallNumber] (the |) (name | nickname | shortcut) [name])
Ignoring a match in nicknames.nameLast because it has slots. (give (the |) (name | nickname | shortcut) [name] to (the |) last [number:smallNumber])
Ignoring a match in nicknames.remove because it has slots. ((remove | delete) (the|) (name | nickname | shortcut) (called |) [name])
Ignoring a match in notes.add because it has slots. ((make | add | write) note{s} (about |) [text] (for me |))
Ignoring a match in read.read because it has slots. (read (me |) [query] (for me | to me |) (aloud |))
Ignoring a match in saving.save because it has slots. ((save | download) (this | active |) (page | html) as [name])
Ignoring a match in saving.downloadScreenshot because it has slots. ((save | download) screenshot (of |) (this | active |) (page | tab | article | site |) as [name])
Ignoring a match in saving.downloadFullPageScreenshot because it has slots. ((save | download) full (page |) screenshot (of |) (this | the |) (active |) (page | tab | article | site |) as [name])
Ignoring a match in saving.downloadFullPageScreenshot because it has slots. ((save | download) (the |) (tab's |) full (page |) (screenshot |) as [name])
Ignoring a match in search.search because it has slots. ((do a |) (query | find | find me | look up | lookup | look on | look for) (google | the web | the internet |) (for |) [query] (on the web |) (for me |))
Ignoring a match in search.searchPage because it has slots. ((do a |) (search | google | look on) (google | the web | the internet |) (for |) [query] (on the web |) (for me|))
```

The resulting file is attached: [all_phrases_without_slots.txt](https://github.com/mozilla/firefox-voice/files/4281384/all_phrases_without_slots.txt)

The logic used by the matching code is simpler than regexes, so maybe using [regex-generate/regenerate](https://github.com/regex-generate/regenerate) is overkill and this can more easily be integrated by implementing the generation logic directly in the code. I also didn't expand simple entities like "smallNumber", which should be fairly simple. The hardest part is probably figuring out how to tap into other sources of data to be able to generate samples from open ended slots like "query" and "name".

I'm not opening this PR expecting anything to be merged, just sharing the script and the results to start a conversation.