### PR TITLE
Add new examples to the rotation

### DIFF
--- a/extension/intents/navigation/navigation.toml
+++ b/extension/intents/navigation/navigation.toml
@@ -109,6 +109,10 @@ expectSlots = {language = "Hungarian"}
 phrase = "translate the selected text to Slovak"
 test = true
 
+[[navigation.translateSelection.example]]
+phrase = "translate this selection to French"
+expectSlots = {language = "French"}
+
 [navigation.followLink]
 description = "Follow the named link"
 match = """

--- a/extension/intents/tabs/tabs.toml
+++ b/extension/intents/tabs/tabs.toml
@@ -228,6 +228,12 @@ expectParameters = {dir = "first"}
 phrase = "Go to the last tab"
 expectParameters = {dir = "last"}
 
+[[tabs.switchDir.example]]
+phrase = "Go to the right tab"
+expectParameters = {dir = "next"}
+
+
+
 [tabs.switchDirPinned]
 description = "Go in some direction of the pinned tabs"
 match = """


### PR DESCRIPTION
Fixes #1057 

This PR adds the following examples to the popup so people know what can be said. Rest of the examples specified in the issue are already in the examples except `Click on link for proper way to drink whisky (opens link on active page)`

- [x] Translate selection to French (will translate highlighted text)

- [x] Go to right tab

I would like to know what @ianb thinks about this.