### PR TITLE
fixes #422 - fixed stop, pause, skip commands

### DIFF
--- a/extension/intents/music/music.toml
+++ b/extension/intents/music/music.toml
@@ -68,7 +68,7 @@ phrase = "Pause music"
 [[music.pause.example]]
 phrase = "pause spotify"
 test = true
-expectParamters = {service = "spotify"}
+expectParameters = {service = "spotify"}
 
 [[music.pause.example]]
 phrase = "stop"
@@ -77,17 +77,17 @@ test = true
 [[music.pause.example]]
 phrase = "stop video"
 test = true
-expectParamters = {service = "youtube"}
+expectParameters = {service = "youtube"}
 
 [[music.pause.example]]
 phrase = "stop playing video"
 test = true
-expectParamters = {service = "youtube"}
+expectParameters = {service = "youtube"}
 
 [[music.pause.example]]
 phrase = "stop playing music"
 test = true
-expectParamters = {service = "youtube"}
+expectParameters = {service = "youtube"}
 
 [music.play]
 description = "Play music on an explicit service, a default service, or the service in the active tab"


### PR DESCRIPTION
Fixes #422 - Added the fix for Stop, Pause Commands not working. Thanks to @ianb  for pointing out the start of the issue.
![Screen-Recording-2020-03-07-at-7](https://user-images.githubusercontent.com/22199666/76145023-aad54880-60ab-11ea-87b8-7436f606f5d5.gif)
