### PR TITLE
add what is playing intent

### DIFF
--- a/extension/intents/music/music.js
+++ b/extension/intents/music/music.js
@@ -116,7 +116,7 @@ intentRunner.registerIntent({
 });
 
 intentRunner.registerIntent({
-  name: "music.find",
+  name: "music.showTitle",
   async run(context) {
     const tabs = await browser.tabs.query({ audible: true });
     if (!tabs.length) {

--- a/extension/intents/music/music.js
+++ b/extension/intents/music/music.js
@@ -115,5 +115,18 @@ intentRunner.registerIntent({
   },
 });
 
+intentRunner.registerIntent({
+  name: "music.find",
+  async run(context) {
+    const tabs = await browser.tabs.query({ audible: true });
+    if (!tabs.length) {
+      const e = new Error("Nothing is playing");
+      e.displayMessage = "Nothing is playing";
+      throw e;
+    }
+    context.displayText(tabs[0].title);
+  },
+});
+
 // FIXME: workaround for a legacy module needing access to this function:
 window.music_getServiceNamesAndTitles = getServiceNamesAndTitles;

--- a/extension/intents/music/music.toml
+++ b/extension/intents/music/music.toml
@@ -144,11 +144,11 @@ phrase = "play music"
 phrase = "play spotify"
 test = true
 
-[music.find]
- description = "Find the tab that's currently making sound"
+[music.showTitle]
+description = "Show the title of the tab that's currently playing a video/audio"
 match = """
-  (what | what's | which ) ( tab | song | music | title ) ( is ) playing 
+  (what | what's | ) ( tab | song | music | title | ) ( is | ) playing
 """
 
-[[music.find.example]]
-phrase = "What song is playing"
+[[music.showTitle.example]]
+phrase = "What is playing"

--- a/extension/intents/music/music.toml
+++ b/extension/intents/music/music.toml
@@ -143,3 +143,12 @@ phrase = "play music"
 [[music.unpause.example]]
 phrase = "play spotify"
 test = true
+
+[music.find]
+ description = "Find the tab that's currently making sound"
+match = """
+  (what | what's | which ) ( tab | song | music | title ) ( is ) playing 
+"""
+
+[[music.find.example]]
+phrase = "What song is playing"


### PR DESCRIPTION
@ianb  

Fixes #1111 

since Youtube and Spotify displays currently playing songs as title, extra services weren't required.
If two songs  plays in two tabs, the first one will be logged out.

this match - what song/music/title is playing - works
this match - what's playing & what is playing - doesn't work. 
can't figure out why.
