### PR TITLE
Navigate to next and previous search result

### DIFF
--- a/extension/browserUtil.js
+++ b/extension/browserUtil.js
@@ -81,7 +81,7 @@ export async function activateTabClickHandler(event) {
   }
 }
 
-export async function createTab(options) {
+export async function createTab(options = {}) {
   const active = await activeTab();
   if (
     ["about:blank", "about:home", "about:newtab"].includes(active.url) ||

--- a/extension/intents/search/search.js
+++ b/extension/intents/search/search.js
@@ -195,6 +195,7 @@ function pollForCard(maxTime) {
 async function moveResult(context, step) {
   stopCardPoll();
   const { tabId, searchInfo } = await getSearchInfo();
+
   if (!searchInfo) {
     const e = new Error("No search made");
     e.displayMessage = "You haven't made a search";
@@ -208,12 +209,17 @@ async function moveResult(context, step) {
     await context.makeTabActive(tabId);
     return;
   }
-  if (!(searchInfo.index + step >= 0)) {
+
+  // Initial search results do not have an index property and we want
+  searchInfo.index =
+    searchInfo.index === undefined ? 0 : searchInfo.index + step;
+
+  if (!(searchInfo.index >= 0)) {
     const e = new Error("No previous search result");
     e.displayMessage = "No previous search result";
     throw e;
   }
-  searchInfo.index += step;
+
   const item = searchInfo.searchResults[searchInfo.index];
   await browser.runtime.sendMessage({
     type: "showSearchResults",

--- a/extension/intents/search/search.js
+++ b/extension/intents/search/search.js
@@ -361,7 +361,12 @@ intentRunner.registerIntent({
   async run(context) {
     await performSearch(context.slots.query);
 
-    if (!buildSettings.android) await focusSearchTab();
+    if (!buildSettings.android) {
+      await focusSearchTab();
+
+      const searchInfo = await callScript({ type: "searchResultInfo" });
+      tabSearchResults.set(_searchTabId, searchInfo);
+    }
   },
 });
 

--- a/extension/intents/search/search.js
+++ b/extension/intents/search/search.js
@@ -201,24 +201,32 @@ async function moveResult(context, step) {
     e.displayMessage = "You haven't made a search";
     throw e;
   }
+
+  // We are on an initial search results page and trying to navigate to a
+  // non-existent previous result
+  if (searchInfo.index === undefined && step < 0) {
+    const e = new Error("No previous search result");
+    e.displayMessage = "No previous search result";
+    throw e;
+  }
+
   if (
     (searchInfo.index >= searchInfo.searchResults.length - 1 && step > 0) ||
     (searchInfo.index <= 0 && step < 0)
   ) {
     const tabId = await openSearchTab();
-    await context.makeTabActive(tabId);
+    await browserUtil.loadUrl(tabId, searchInfo.searchUrl);
+
+    // reset the index to an initial search result
+    searchInfo.index = undefined;
+    tabSearchResults.set(tabId, searchInfo);
     return;
   }
 
-  // Initial search results do not have an index property and we want
+  // Initial search results do not have an index property and at this point
+  // we wish to start navigating
   searchInfo.index =
     searchInfo.index === undefined ? 0 : searchInfo.index + step;
-
-  if (!(searchInfo.index >= 0)) {
-    const e = new Error("No previous search result");
-    e.displayMessage = "No previous search result";
-    throw e;
-  }
 
   const item = searchInfo.searchResults[searchInfo.index];
   await browser.runtime.sendMessage({

--- a/extension/intents/search/search.js
+++ b/extension/intents/search/search.js
@@ -359,13 +359,9 @@ intentRunner.registerIntent({
 intentRunner.registerIntent({
   name: "search.searchPage",
   async run(context) {
-    if (buildSettings.android) {
-      await performSearch(context.slots.query);
-    } else {
-      await browser.search.search({
-        query: context.slots.query,
-      });
-    }
+    await performSearch(context.slots.query);
+
+    if (!buildSettings.android) await focusSearchTab();
   },
 });
 

--- a/extension/intents/search/search.js
+++ b/extension/intents/search/search.js
@@ -373,13 +373,22 @@ intentRunner.registerIntent({
 intentRunner.registerIntent({
   name: "search.searchPage",
   async run(context) {
-    await performSearch(context.slots.query);
+    if (buildSettings.android) {
+      await performSearch(context.slots.query);
+    } else {
+      const tabId = await openSearchTab();
 
-    if (!buildSettings.android) {
+      await browser.search.search({
+        query: context.slots.query,
+        tabId,
+      });
+
       await focusSearchTab();
 
+      await content.lazyInject(tabId, "/intents/search/queryScript.js");
       const searchInfo = await callScript({ type: "searchResultInfo" });
-      tabSearchResults.set(_searchTabId, searchInfo);
+
+      tabSearchResults.set(tabId, searchInfo);
     }
   },
 });


### PR DESCRIPTION
This pull request addresses an issue where the command "next result" would throw an error to the user and not navigate properly.

To fix this, I had to use the provided function `performSearch` since the native extension javascript api—`browser.search.search`—would not provide any information about the search results or the tab.

Next, I added the ability for the command "previous results" to navigate to the search page, if currently on the first result.

I did not add any tests, since I did not see any for this part of the codebase. But if you'd like some, I can add those as well.

Closes #864 

Before submitting a final PR, please:

- [x] Run `npm test` on your machine
- [x] Run `npm run format` to keep code formatted consistently
