### PR TITLE
Fix music.pause intent for jest

### DIFF
--- a/extension/intents/music/music.toml
+++ b/extension/intents/music/music.toml
@@ -58,7 +58,7 @@ description = "Pause all supported services (regardless of tab or window)"
 match = """
   (stop | pause) (play | playing |) video [service=youtube]
   pause [service:musicServiceName]
-  pause (play | playing |) (music |)
+  pause (play | playing |) (music |) 
   stop (play | playing |) (music |)
 """
 
@@ -68,7 +68,8 @@ phrase = "Pause music"
 [[music.pause.example]]
 phrase = "pause spotify"
 test = true
-expectParameters = {service = "spotify"}
+expectParameters = {}
+expectSlots = {service = "spotify"}
 
 [[music.pause.example]]
 phrase = "stop"
@@ -87,7 +88,6 @@ expectParameters = {service = "youtube"}
 [[music.pause.example]]
 phrase = "stop playing music"
 test = true
-expectParameters = {service = "youtube"}
 
 [music.play]
 description = "Play music on an explicit service, a default service, or the service in the active tab"


### PR DESCRIPTION
Before submitting a final PR, please:

- [x] Run `npm test` on your machine
- [x] Run `npm run format` to keep code formatted consistently

Fixed a couple of errors in corresponding .TOML file that was causing Jest tests to fail. Fixes #1184 
