### PR TITLE
Adds plural phrases in bookmark removal

### DIFF
--- a/extension/intents/bookmarks/bookmarks.toml
+++ b/extension/intents/bookmarks/bookmarks.toml
@@ -64,3 +64,11 @@ test = true
 [[bookmarks.remove.example]]
 phrase = "Delete bookmark from this page"
 test = true
+
+[[bookmarks.remove.example]]
+phrase = "Remove bookmarks"
+test = true
+
+[[bookmarks.remove.example]]
+phrase = "Delete bookmarks from this page"
+test = true

--- a/extension/intents/bookmarks/bookmarks.toml
+++ b/extension/intents/bookmarks/bookmarks.toml
@@ -45,8 +45,8 @@ expectSlots = { query = "query" }
 [bookmarks.remove]
 description = "Remove bookmark from the default folder (Other Bookmarks)"
 match = """
-  (remove | delete) bookmark (from |) (this |) (page | site | tab |) (for me |)
-  (remove | delete) (this |) (page | site | tab |) from bookmarks
+  (remove | delete) bookmark{s} (from |) (this |) (page | site | tab |) (for me |)
+  (remove | delete) (this |) (page | site | tab |) from bookmark{s}
 """
 
 [[bookmarks.remove.example]]


### PR DESCRIPTION
In reference to the [comment](https://github.com/mozilla/firefox-voice/issues/1132#issuecomment-597047257) made on previous PR. 

Now both bookmark and bookmarks will work while removing bookmark.

- Delete bookmarks from this page
- Remove bookmarks



Before submitting a final PR, please:

- [x] Run `npm test` on your machine
- [x] Run `npm run format` to keep code formatted consistently
