### PR TITLE
fixes simultaneous playing of tabs when unpause intent is given

### DIFF
--- a/extension/intents/music/music.js
+++ b/extension/intents/music/music.js
@@ -94,6 +94,10 @@ intentRunner.registerIntent({
 intentRunner.registerIntent({
   name: "music.unpause",
   async run(context) {
+    for (const ServiceClass of Object.values(SERVICES)) {
+      const service = new ServiceClass(context);
+      await service.pauseAny();
+    }
     const service = await getService(context, { lookAtCurrentTab: true });
     await service.unpause();
   },

--- a/extension/intents/music/music.js
+++ b/extension/intents/music/music.js
@@ -2,6 +2,7 @@
 
 import * as intentRunner from "../../background/intentRunner.js";
 import * as serviceList from "../../background/serviceList.js";
+import * as browserUtil from "../../browserUtil.js";
 
 const SERVICES = {};
 
@@ -96,7 +97,7 @@ intentRunner.registerIntent({
   async run(context) {
     for (const ServiceClass of Object.values(SERVICES)) {
       const service = new ServiceClass(context);
-      await service.pauseAny();
+      await service.pauseAny({exceptTabId: (await browserUtil.activeTab()).id});
     }
     const service = await getService(context, { lookAtCurrentTab: true });
     await service.unpause();


### PR DESCRIPTION
Before submitting a final PR, please:

- [x] Run `npm test` on your machine
- [x] Run `npm run format` to keep code formatted consistently

fixes #408 
The following change pauses every tab first and then unpauses the specified tab.