### PR TITLE
fixed bug - 'Unmute this page' doesn't work #1220

### DIFF
--- a/extension/background/language/general.test.js
+++ b/extension/background/language/general.test.js
@@ -18,6 +18,12 @@ test("compiler", () => {
     'FullPhrase("(bring me | take me | go | navigate | show me | open) (to | find | ) (page | ) [query:+]")'
   );
 
+  expect(
+    compile("(unmute|turn on) (tab{s} |page{s}) (for me |)").toString()
+  ).toBe(
+    'FullPhrase("(unmute | turn on) (tab | tabs | page | pages) (for me | )")'
+  );
+
   expect(compile("clear query (database | cache)").toString()).toBe(
     'FullPhrase("clear query (database | cache)")'
   );

--- a/extension/background/language/general.test.js
+++ b/extension/background/language/general.test.js
@@ -19,7 +19,7 @@ test("compiler", () => {
   );
 
   expect(
-    compile("(unmute|turn on) (tab{s} |page{s}) (for me |)").toString()
+    compile("(unmute | turn on) (tab{s} | page{s}) (for me |)").toString()
   ).toBe(
     'FullPhrase("(unmute | turn on) (tab | tabs | page | pages) (for me | )")'
   );

--- a/extension/intents/muting/muting.toml
+++ b/extension/intents/muting/muting.toml
@@ -40,5 +40,18 @@ test = true
 [muting.unmute]
 description = "Unmute all tabs"
 match = """
-  unmute (tab{s} |) (for me |)
+  (unmute|turn on) (tab{s} |page{s}) (for me |)
+   unmute
 """
+
+[[muting.unmute.example]]
+phrase = "unmute this page"
+test = true
+
+[[muting.unmute.example]]
+phrase = "unmute"
+test = true
+
+[[muting.unmute.example]]
+phrase = "turn on this tab"
+test = true

--- a/extension/intents/muting/muting.toml
+++ b/extension/intents/muting/muting.toml
@@ -40,7 +40,7 @@ test = true
 [muting.unmute]
 description = "Unmute all tabs"
 match = """
-  (unmute|turn on) (tab{s} |page{s}) (for me |)
+  (unmute | turn on) (tab{s} | page{s}) (for me |)
    unmute
 """
 


### PR DESCRIPTION
This PR references issue #1220 

Changes:
1. Added a new matching for "unmute" intent:
extension/intents/muting/muting.toml: line 43 - 57

2. Added test cases for the change:
extension/background/language/general.test.js: line 20 - 25

Before submitting a final PR, please:

- [x] Run `npm test` on your machine
- [x] Run `npm run format` to keep code formatted consistently
