### PR TITLE
Scrape search results from Bing and DuckDuckGo

### DIFF
--- a/extension/intents/search/queryScript.js
+++ b/extension/intents/search/queryScript.js
@@ -95,26 +95,12 @@ this.queryScript = (function() {
     const GOOGLE_SELECTOR = "a > h3";
     const DDG_SELECTOR = "#links .results_links_deep .result__a";
     const BING_SELECTOR = ".b_algo h2 a";
-    let searchEngine = "google";
+    const origin = window.location.origin;
+    let selector = GOOGLE_SELECTOR;
     let cards;
 
-    if (message && message.searchEngine && message.searchEngine.toLowerCase()) {
-      searchEngine = message.searchEngine.toLowerCase();
-    }
-
-    let selector;
-
-    switch (searchEngine) {
-      case "duckduckgo":
-        selector = DDG_SELECTOR;
-        break;
-      case "bing":
-        selector = BING_SELECTOR;
-        break;
-      default:
-        cards = findCards();
-        selector = GOOGLE_SELECTOR;
-    }
+    if (/duckduckgo/i.test(origin)) selector = DDG_SELECTOR;
+    else if (/bing/i.test(origin)) selector = BING_SELECTOR;
 
     const searchHeaders = document.querySelectorAll(selector);
     const searchResults = [];
@@ -128,7 +114,7 @@ this.queryScript = (function() {
 
       searchResults.push({
         url:
-          searchEngine === "google"
+          selector === GOOGLE_SELECTOR
             ? searchHeader.parentNode.href
             : searchHeader.href,
         title: searchHeader.textContent,

--- a/extension/intents/search/search.js
+++ b/extension/intents/search/search.js
@@ -392,13 +392,7 @@ intentRunner.registerIntent({
 
       await focusSearchTab();
       await content.lazyInject(tabId, "/intents/search/queryScript.js");
-
-      const engines = await browser.search.get();
-
-      const searchInfo = await callScript({
-        type: "searchResultInfo",
-        searchEngine: engines.find(engine => engine.isDefault).name,
-      });
+      const searchInfo = await callScript({ type: "searchResultInfo" });
 
       if (
         searchInfo.searchResults === undefined ||

--- a/extension/intents/search/search.js
+++ b/extension/intents/search/search.js
@@ -391,9 +391,25 @@ intentRunner.registerIntent({
       });
 
       await focusSearchTab();
-
       await content.lazyInject(tabId, "/intents/search/queryScript.js");
-      const searchInfo = await callScript({ type: "searchResultInfo" });
+
+      const engines = await browser.search.get();
+
+      const searchInfo = await callScript({
+        type: "searchResultInfo",
+        searchEngine: engines.find(engine => engine.isDefault).name,
+      });
+
+      if (
+        searchInfo.searchResults === undefined ||
+        !searchInfo.searchResults.length > 0
+      ) {
+        const msg =
+          "Could not get list of search results.\n\nPlease click feedback to let us know.";
+        const e = new Error(msg);
+        e.displayMessage = msg;
+        throw e;
+      }
 
       tabSearchResults.set(tabId, searchInfo);
     }

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -188,6 +188,7 @@ body,
   font-weight: 600;
   padding: 1.5rem 0;
   color: #800;
+  white-space: pre-wrap;
 }
 
 .typing #text-input-field {


### PR DESCRIPTION
Currently the only search engine being scraped for results is Google. This PR scrapes from Bing and DuckDuckGo. 

I originally wanted to rely solely on the document structure, but code reusability would decrease by re-implementing logic for each engine. Since—unlike Google—Bing and DuckDuckGo use BEM to structure their classes, I felt this should be sufficient for now.

I also throw an error (screenshot below) if search results cannot be scraped, which instructs the user to inform us. This would help us address the moment the structure or classes change. For this I had to add the `white-space` rule to prevent newlines from collapsing.

closes: #1213

**NOTE:**
In the matrix chat room, it was mentioned that the expected behavior of `search.searchPage` was to open a new search tab even if one was already open. I assumed the intended behavior was to reuse the search tab. If you'd like this change to be reverted, let me know so I can add it to this PR

Screenshot:
![Screen Shot 2020-03-11 at 14 47 18](https://user-images.githubusercontent.com/24993360/76452715-f2a7e880-63a7-11ea-8447-03245425040c.png)

Before submitting a final PR, please:

- [x] Run `npm test` on your machine
- [x] Run `npm run format` to keep code formatted consistently
