### PR TITLE
Fixed Scrolling on pdf files

### DIFF
--- a/extension/intents/scroll/scrollHelper.js
+++ b/extension/intents/scroll/scrollHelper.js
@@ -2,8 +2,13 @@
 
 const scrollAmount = 0.9;
 
+let url = location.href;
+let pdf = url.slice(-4) === ".pdf";
+let activeEl = document.activeElement;
+let targetEl = pdf ? activeEl : window;
+
 function scrollVertically(dy, smooth) {
-  window.scrollBy({
+  targetEl.scrollBy({
     left: 0,
     top: dy,
     behavior: smooth ? "smooth" : "auto",
@@ -24,13 +29,15 @@ function scrollDown() {
 communicate.register("scrollDown", scrollDown);
 
 function scrollToTop() {
-  return scrollVertically(-window.scrollY, false);
+  let topHeight = pdf ? targetEl.scrollHeight : window.scrollY;
+  return scrollVertically(-topHeight, false);
 }
 
 communicate.register("scrollToTop", scrollToTop);
 
 function scrollToBottom() {
-  return scrollVertically(document.body.scrollHeight - window.scrollY, false);
+  let bottomHeight = pdf ? targetEl.scrollHeight : document.body.scrollHeight;
+  return scrollVertically(bottomHeight - window.scrollY, false);
 }
 
 communicate.register("scrollToBottom", scrollToBottom);

--- a/extension/intents/scroll/scrollHelper.js
+++ b/extension/intents/scroll/scrollHelper.js
@@ -2,10 +2,10 @@
 
 const scrollAmount = 0.9;
 
-let url = location.href;
-let pdf = url.slice(-4) === ".pdf";
-let activeEl = document.activeElement;
-let targetEl = pdf ? activeEl : window;
+const url = location.href;
+const pdf = url.slice(-4) === ".pdf";
+const activeEl = document.activeElement;
+const targetEl = pdf ? activeEl : window;
 
 function scrollVertically(dy, smooth) {
   targetEl.scrollBy({
@@ -29,14 +29,14 @@ function scrollDown() {
 communicate.register("scrollDown", scrollDown);
 
 function scrollToTop() {
-  let topHeight = pdf ? targetEl.scrollHeight : window.scrollY;
+  const topHeight = pdf ? targetEl.scrollHeight : window.scrollY;
   return scrollVertically(-topHeight, false);
 }
 
 communicate.register("scrollToTop", scrollToTop);
 
 function scrollToBottom() {
-  let bottomHeight = pdf ? targetEl.scrollHeight : document.body.scrollHeight;
+  const bottomHeight = pdf ? targetEl.scrollHeight : document.body.scrollHeight;
   return scrollVertically(bottomHeight - window.scrollY, false);
 }
 


### PR DESCRIPTION
Before submitting a final PR, please:

- [x] Run `npm test` on your machine
- [x] Run `npm run format` to keep code formatted consistently

Issue I was working on: https://github.com/mozilla/firefox-voice/issues/954
Found a solution by first checking if the file is a pdf, if so, the target element is the activeElement instead of the window.