### PR TITLE
Attempt to add intent to make video full screen

### DIFF
--- a/extension/intents/music/music.js
+++ b/extension/intents/music/music.js
@@ -130,7 +130,10 @@ intentRunner.registerIntent({
       exc.displayMessage = exc.message;
       throw exc;
     }
-    const audibleTab = await browser.tabs.query({ active: true, audible: true });
+    const audibleTab = await browser.tabs.query({
+      active: true,
+      audible: true,
+    });
     if (!audibleTab.length) {
       const currentWindow = await browser.windows.getCurrent();
       await browser.windows.update(currentWindow.id, { state: "fullscreen" });

--- a/extension/intents/music/music.js
+++ b/extension/intents/music/music.js
@@ -1,4 +1,4 @@
-/* globals log */
+/* globals buildSettings, log */
 
 import * as intentRunner from "../../background/intentRunner.js";
 import * as serviceList from "../../background/serviceList.js";
@@ -119,6 +119,25 @@ intentRunner.registerIntent({
   async run(context) {
     const service = await getService(context, { lookAtCurrentTab: true });
     await service.move(context.parameters.direction);
+  },
+});
+
+intentRunner.registerIntent({
+  name: "music.fullScreen",
+  async run(context) {
+    if (buildSettings.android) {
+      const exc = new Error("Full screen not supported on Android");
+      exc.displayMessage = exc.message;
+      throw exc;
+    }
+    const audibleTab = await browser.tabs.query({ active: true, audible: true });
+    if (!audibleTab.length) {
+      const currentWindow = await browser.windows.getCurrent();
+      await browser.windows.update(currentWindow.id, { state: "fullscreen" });
+    } else {
+      const service = await getService(context, { lookAtCurrentTab: true });
+      await service.fullScreenVideo(audibleTab[0].id);
+    }
   },
 });
 

--- a/extension/intents/music/music.toml
+++ b/extension/intents/music/music.toml
@@ -156,3 +156,21 @@ phrase = "What is playing"
 [[music.showTitle.example]]
 phrase = "What's playing?"
 test = true
+
+[music.fullScreen]
+description = "Full screen mode"
+match = """
+  (make |) (full screen | fullscreen)
+"""
+
+[[music.fullScreen.example]]
+phrase = "full screen"
+
+[music.exitFullScreen]
+description = "Full screen mode"
+match = """
+  (exit |) (full screen | fullscreen)
+"""
+
+[[music.exitFullScreen.example]]
+phrase = "exit screen"

--- a/extension/intents/tabs/tabs.js
+++ b/extension/intents/tabs/tabs.js
@@ -217,19 +217,6 @@ intentRunner.registerIntent({
   },
 });
 
-intentRunner.registerIntent({
-  name: "tabs.fullScreen",
-  async run(context) {
-    if (buildSettings.android) {
-      const exc = new Error("Full screen not supported on Android");
-      exc.displayMessage = exc.message;
-      throw exc;
-    }
-    const currentWindow = await browser.windows.getCurrent();
-    await browser.windows.update(currentWindow.id, { state: "fullscreen" });
-  },
-});
-
 const tabHistory = [];
 let lastActivate;
 

--- a/extension/intents/tabs/tabs.toml
+++ b/extension/intents/tabs/tabs.toml
@@ -45,15 +45,6 @@ match = """
 [[tabs.duplicate.example]]
 phrase = "Duplicate this page"
 
-[tabs.fullScreen]
-description = "Full screen mode"
-match = """
-  (make |) (full screen | fullscreen)
-"""
-
-[[tabs.fullScreen.example]]
-phrase = "full screen"
-
 [tabs.moveToWindow]
 description = "Move tab in a new window"
 match = """

--- a/extension/services/youtube/player.js
+++ b/extension/services/youtube/player.js
@@ -62,7 +62,9 @@ this.player = (function() {
     }
 
     action_fullScreenVideo() {
-      const button = this.querySelector(`${this.selector} .ytp-fullscreen-button`);
+      const button = this.querySelector(
+        `${this.selector} .ytp-fullscreen-button`
+      );
       button.click();
       // const video = this.querySelector(this.videoPlayer);
       // return video.mozRequestFullScreen();

--- a/extension/services/youtube/player.js
+++ b/extension/services/youtube/player.js
@@ -60,6 +60,13 @@ this.player = (function() {
       const button = this.querySelector(`${this.selector} .ytp-next-button`);
       button.click();
     }
+
+    action_fullScreenVideo() {
+      const button = this.querySelector(`${this.selector} .ytp-fullscreen-button`);
+      button.click();
+      // const video = this.querySelector(this.videoPlayer);
+      // return video.mozRequestFullScreen();
+    }
   }
 
   Player.register();

--- a/extension/services/youtube/youtube.js
+++ b/extension/services/youtube/youtube.js
@@ -92,8 +92,8 @@ class YouTube extends serviceList.Service {
   }
 
   async fullScreenVideo(tabId) {
-      await content.lazyInject(tabId, "/services/youtube/player.js");
-      await this.callOneTab(tabId, "fullScreenVideo");
+    await content.lazyInject(tabId, "/services/youtube/player.js");
+    await this.callOneTab(tabId, "fullScreenVideo");
   }
 }
 

--- a/extension/services/youtube/youtube.js
+++ b/extension/services/youtube/youtube.js
@@ -90,6 +90,11 @@ class YouTube extends serviceList.Service {
       await this.callOneTab(tab.id, "move", { direction });
     }
   }
+
+  async fullScreenVideo(tabId) {
+      await content.lazyInject(tabId, "/services/youtube/player.js");
+      await this.callOneTab(tabId, "fullScreenVideo");
+  }
 }
 
 Object.assign(YouTube, {


### PR DESCRIPTION
I was looking into this issue #995 and could use your expertise when you have a moment, as I ultimately keep getting the error below.

<img width="837" alt="Screen Shot 2020-03-15 at 4 11 38 PM" src="https://user-images.githubusercontent.com/28129806/76710008-01f5a180-66da-11ea-8913-49fb7046ece3.png">

As advised in the issue, I updated the current fullscreen intent, so that new phrases were not needed - though I did move the intents from `extension/intents/tabs/tabs.js` to `extension/intents/music/music.js` so I would have access to `extension/services/youtube/player.js`.

Attempts:
1. Utilized `.requestFullscreen()`; got the error above -- `mozRequestFullScreen()` has been deprecated
2. Tried to target the button instead as the other controls were solved; still got the error above
3. In devtools, I targeted the button in the console; still got the error. (Sidenote: the button does not have an aria-label or title like the other buttons).

I'm not sure if the response time isn't short enough (1 sec), or it's just not possible? Any guidance would be greatly appreciated!