### PR TITLE
RE: Close active tab alias

### DIFF
--- a/extension/intents/tabs/tabs.toml
+++ b/extension/intents/tabs/tabs.toml
@@ -1,12 +1,18 @@
 [tabs.close]
 description = "Closes the current tab"
 match = """
-  close (this |) (current |) (tab | site | page) (for me |)
-  close (this | that)
+  close (the| this |) (active| current |) (tab | site | page) (for me |)
+  close (the| this | that)
 """
 
 [[tabs.close.example]]
 phrase = "close tab"
+
+[[tabs.close.example]]
+phrase = "close active tab"
+
+[[tabs.close.example]]
+phrase = "close the active tab"
 
 [[tabs.close.example]]
 phrase = "close the current top"


### PR DESCRIPTION
Fixes #1298

I noticed the word "active" was not supported/included in the "tabs.close" intent, please review and let me know if it is necessary. If it is not, I will close this pull request. Thanks!

