### PR TITLE
Name page intent

### DIFF
--- a/extension/intents/navigation/navigation.js
+++ b/extension/intents/navigation/navigation.js
@@ -31,7 +31,7 @@ function saveTabQueryToDatabase(query, tab, url) {
 intentRunner.registerIntent({
   name: "navigation.navigate",
   async run(context) {
-    const query = context.slots.query;
+    const query = context.slots.query.toLowerCase();
     const result = await browser.storage.sync.get("pageNames");
     const pageNames = result.pageNames;
     const savedUrl = pageNames[query];

--- a/extension/intents/navigation/navigation.js
+++ b/extension/intents/navigation/navigation.js
@@ -32,23 +32,30 @@ intentRunner.registerIntent({
   name: "navigation.navigate",
   async run(context) {
     const query = context.slots.query;
-    const where = context.slots.where;
-    const cached = queryDatabase.get(query.toLowerCase());
-    if (where === "window") {
-      if (cached) {
-        await browser.windows.create({ url: cached.url });
+    const result = await browser.storage.sync.get("pageNames");
+    const pageNames = result.pageNames;
+    const savedUrl = pageNames[query];
+    if (savedUrl) {
+      await context.openOrFocusTab(savedUrl);
+    } else {
+      const where = context.slots.where;
+      const cached = queryDatabase.get(query.toLowerCase());
+      if (where === "window") {
+        if (cached) {
+          await browser.windows.create({ url: cached.url });
+        } else {
+          await browser.windows.create({});
+          const tab = await context.createTabGoogleLucky(query);
+          const url = tab.url;
+          saveTabQueryToDatabase(query, tab, url);
+        }
+      } else if (cached) {
+        await context.openOrFocusTab(cached.url);
       } else {
-        await browser.windows.create({});
         const tab = await context.createTabGoogleLucky(query);
         const url = tab.url;
         saveTabQueryToDatabase(query, tab, url);
       }
-    } else if (cached) {
-      await context.openOrFocusTab(cached.url);
-    } else {
-      const tab = await context.createTabGoogleLucky(query);
-      const url = tab.url;
-      saveTabQueryToDatabase(query, tab, url);
     }
     context.done();
   },

--- a/extension/intents/navigation/navigation.toml
+++ b/extension/intents/navigation/navigation.toml
@@ -63,7 +63,7 @@ match = """
 """
 
 [navigation.navigate]
-description = "Navigate directly to a site, using Google's I'm Feeling Luck and the query"
+description = "Navigate to the named page or if does not exist, directly to a site, using Google's I'm Feeling Luck and the query"
 match = """
   (bring me | take me | go | navigate | show me | open) (to | find |) (page |) [query]
   (bring me | take me | go | navigate | show me | open) (to | find |) (page |) (in |) (a |) (new |) [where] (and go | and |) (to | find | open) [query]

--- a/extension/intents/nicknames/nicknames.js
+++ b/extension/intents/nicknames/nicknames.js
@@ -131,3 +131,32 @@ intentRunner.registerIntent({
     await browser.storage.sync.set({ pageNames });
   },
 });
+
+intentRunner.registerIntent({
+  name: "nicknames.removePageName",
+  async run(context) {
+    const result = await browser.storage.sync.get("pageNames");
+    const pageNames = result.pageNames || {};
+    const getName = async () => {
+      const activeTab = await context.activeTab();
+      const metadata = await pageMetadata.getMetadata(activeTab.id);
+      return Object
+        .keys(pageNames)
+        .find(key => pageNames[key] === metadata.url);
+    };
+    const name = context.slots.name || await getName();
+    if (!name) {
+      const exc = new Error("No page name to remove");
+      exc.displayMessage = `This page does not have a name`;
+      throw exc;
+    }
+    if (!pageNames[name]) {
+      const exc = new Error("No page name to remove");
+      exc.displayMessage = `No page name "${name}" found`;
+      throw exc;
+    }
+    delete pageNames[name];
+    log.info("Removed page name", name);
+    await browser.storage.sync.set({ pageNames });
+  },
+});

--- a/extension/intents/nicknames/nicknames.js
+++ b/extension/intents/nicknames/nicknames.js
@@ -125,12 +125,9 @@ intentRunner.registerIntent({
     const activeTab = await context.activeTab();
     const metadata = await pageMetadata.getMetadata(activeTab.id);
     const result = await browser.storage.sync.get("pageNames");
-    let pageNames = result.pageNames;
-    if (!pageNames) {
-      pageNames = { [name]: metadata.url };
-    } else {
-      pageNames[name] = metadata.url;
-    }
+    const pageNames = result.pageNames || {};
+    pageNames[name] = metadata.url;
+    log.info("Added page name", name);
     await browser.storage.sync.set({ pageNames });
   },
 });

--- a/extension/intents/nicknames/nicknames.js
+++ b/extension/intents/nicknames/nicknames.js
@@ -121,13 +121,13 @@ intentRunner.registerIntent({
 intentRunner.registerIntent({
   name: "nicknames.namePage",
   async run(context) {
-    const name = context.slots.name;
+    const name = context.slots.name.toLowerCase();
     const activeTab = await context.activeTab();
     const metadata = await pageMetadata.getMetadata(activeTab.id);
     const result = await browser.storage.sync.get("pageNames");
     let pageNames = result.pageNames;
     if (!pageNames) {
-      pageNames = {[name]: metadata.url};
+      pageNames = { [name]: metadata.url };
     } else {
       pageNames[name] = metadata.url;
     }

--- a/extension/intents/nicknames/nicknames.js
+++ b/extension/intents/nicknames/nicknames.js
@@ -1,6 +1,7 @@
 /* globals log */
 
 import * as intentRunner from "../../background/intentRunner.js";
+import * as pageMetadata from "../../background/pageMetadata.js";
 
 intentRunner.registerIntent({
   name: "nicknames.name",
@@ -114,5 +115,22 @@ intentRunner.registerIntent({
         break;
       }
     }
+  },
+});
+
+intentRunner.registerIntent({
+  name: "nicknames.namePage",
+  async run(context) {
+    const name = context.slots.name;
+    const activeTab = await context.activeTab();
+    const metadata = await pageMetadata.getMetadata(activeTab.id);
+    const result = await browser.storage.sync.get("pageNames");
+    let pageNames = result.pageNames;
+    if (!pageNames) {
+      pageNames = {[name]: metadata.url};
+    } else {
+      pageNames[name] = metadata.url;
+    }
+    await browser.storage.sync.set({ pageNames });
   },
 });

--- a/extension/intents/nicknames/nicknames.toml
+++ b/extension/intents/nicknames/nicknames.toml
@@ -36,7 +36,7 @@ match = """
 phrase = "Remove name calendar"
 
 [nicknames.namePage]
-description = "Name page"
+description = "Name a page"
 match = """
  name (this |) (this | page | tab) [name]
  give (the |) name [name] to (this |) (page | tab)
@@ -48,3 +48,16 @@ phrase = "name this page news"
 [[nicknames.namePage.example]]
 phrase = "give the name news to this tab"
 test = true
+
+[nicknames.removePageName]
+description = "Remove a page name"
+match = """
+  (remove | delete) (the |) (page | tab) (name | nickname | shortcut |) (called |) [name] 
+  (remove | delete) (the | this |) (page | tab) name
+"""
+
+[[nicknames.removePageName.example]]
+phrase = "delete the page called news"
+
+[[nicknames.removePageName.example]]
+phrase = "remove this tab name"

--- a/extension/intents/nicknames/nicknames.toml
+++ b/extension/intents/nicknames/nicknames.toml
@@ -34,3 +34,17 @@ match = """
 
 [[nicknames.remove.example]]
 phrase = "Remove name calendar"
+
+[nicknames.namePage]
+description = "Name page"
+match = """
+ name (this |) (this | page | tab) [name]
+ give (the |) name [name] to (this |) (page | tab)
+"""
+
+[[nicknames.namePage.example]]
+phrase = "name this page news"
+
+[[nicknames.namePage.example]]
+phrase = "give the name news to this tab"
+test = true


### PR DESCRIPTION
Closes #808 

A few points:
1. **Intent name**
I named it page instead of tab, because I think it is more suitable, as the word tab could mean something else - I could visit multiple websites/web pages in one tab, but I want to name only a particular web page. Please correct me if I am wrong.

2. **Intents for naming, removing a name and renaming a page**
I added the intent for naming a specific web page (e.g., `name this tab news`) as suggested. I also added intent for removing either the name of the currently opened page or the name of some page called `[name]`. I think an intent for renaming the page is also needed.

3. **Changing other associated intents**
I added opening the page using the command `open [name]` and similar formulations. 
_How I implemented that_: I found that `navigation.js` is used at the moment for this type of command. At first, I made a separate intent not to change the logic of navigation intent (it mainly does direct google search), but it turned out that `matching.js` treats both intent matches equally but navigation intent is preferred as it comes first. Thus, I changed the logic of navigation itself to check first whether the nickname (query) already exists among the stored page names in the storage. Only if it does not, it tries direct google search. What do you think about this? The other usages (e.g., `close [name]`) are yet to be implemented.

@ianb Will be glad to hear your feedback to make sure I am in the right direction

Before submitting a final PR, please:

- [x] Run `npm test` on your machine
- [x] Run `npm run format` to keep code formatted consistently
- [ ] Reference the issue you are fixing in at least one of your commit messages, as `Fixes #X`
