### PR TITLE
Create start slideshow intent

### DIFF
--- a/extension/intents/music/music.js
+++ b/extension/intents/music/music.js
@@ -97,7 +97,9 @@ intentRunner.registerIntent({
   async run(context) {
     for (const ServiceClass of Object.values(SERVICES)) {
       const service = new ServiceClass(context);
-      await service.pauseAny({exceptTabId: (await browserUtil.activeTab()).id});
+      await service.pauseAny({
+        exceptTabId: (await browserUtil.activeTab()).id,
+      });
     }
     const service = await getService(context, { lookAtCurrentTab: true });
     await service.unpause();

--- a/extension/intents/slideshow/contentScript.css
+++ b/extension/intents/slideshow/contentScript.css
@@ -1,67 +1,68 @@
 .fv-lightbox-container {
-    height: 100%;
-    width: 100%;
-    background-color: rgba(0,0,0,0.8);
-    z-index: 100;
-    position: fixed;
-    top:0;
-    left: 0;
-    display: none;
+  height: 100%;
+  width: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  z-index: 100;
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: none;
 }
 
-.fv-slideshow-container {  
-    display: flex;     
-    position: relative;
-    height: 80%;    
-    width: 60%;
-    border: 12px solid whitesmoke;
-    border-radius: 7px;
-    background-color: dimgray; 
-    margin: 3% auto; 
-    justify-content: center;
+.fv-slideshow-container {
+  display: flex;
+  position: relative;
+  height: 80%;
+  width: 60%;
+  border: 12px solid whitesmoke;
+  border-radius: 7px;
+  background-color: dimgray;
+  margin: 3% auto;
+  justify-content: center;
 }
 
 .fv-slide-image img {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;  
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .fv-slide-image video {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .fv-slide-image iframe {
-    margin-top: 5%;
+  margin-top: 5%;
 }
 
-.fv-prev, .fv-next {
-    cursor: pointer;
-    position: absolute;
-    top: 50%;
-    width: auto;
-    margin-top: -22px;
-    padding: 16px;
-    color: white;
-    font-weight: bold;
-    font-size: 18px;
-    transition: 0.6s ease;    
-    user-select: none;
+.fv-prev,
+.fv-next {
+  cursor: pointer;
+  position: absolute;
+  top: 50%;
+  width: auto;
+  margin-top: -22px;
+  padding: 16px;
+  color: white;
+  font-weight: bold;
+  font-size: 18px;
+  transition: 0.6s ease;
+  user-select: none;
 }
 
 .fv-next {
-    right: 0;
-    border-radius: 3px 0 0 3px;
+  right: 0;
+  border-radius: 3px 0 0 3px;
 }
 
 .fv-prev {
-    left: 0;
-    border-radius:  0 3px 3px 0;
+  left: 0;
+  border-radius: 0 3px 3px 0;
 }
 
-.fv-next:hover, .fv-prev:hover {
-    background-color: rgba(0,0,0,0.8);
+.fv-next:hover,
+.fv-prev:hover {
+  background-color: rgba(0, 0, 0, 0.8);
 }

--- a/extension/intents/slideshow/contentScript.css
+++ b/extension/intents/slideshow/contentScript.css
@@ -1,0 +1,67 @@
+.fv-lightbox-container {
+    height: 100%;
+    width: 100%;
+    background-color: rgba(0,0,0,0.8);
+    z-index: 100;
+    position: fixed;
+    top:0;
+    left: 0;
+    display: none;
+}
+
+.fv-slideshow-container {  
+    display: flex;     
+    position: relative;
+    height: 80%;    
+    width: 60%;
+    border: 12px solid whitesmoke;
+    border-radius: 7px;
+    background-color: dimgray; 
+    margin: 3% auto; 
+    justify-content: center;
+}
+
+.fv-slide-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;  
+}
+
+.fv-slide-image video {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+
+}
+
+.fv-slide-image iframe {
+    margin-top: 5%;
+}
+
+.fv-prev, .fv-next {
+    cursor: pointer;
+    position: absolute;
+    top: 50%;
+    width: auto;
+    margin-top: -22px;
+    padding: 16px;
+    color: white;
+    font-weight: bold;
+    font-size: 18px;
+    transition: 0.6s ease;    
+    user-select: none;
+}
+
+.fv-next {
+    right: 0;
+    border-radius: 3px 0 0 3px;
+}
+
+.fv-prev {
+    left: 0;
+    border-radius:  0 3px 3px 0;
+}
+
+.fv-next:hover, .fv-prev:hover {
+    background-color: rgba(0,0,0,0.8);
+}

--- a/extension/intents/slideshow/contentScript.js
+++ b/extension/intents/slideshow/contentScript.js
@@ -1,0 +1,155 @@
+/* globals communicate */
+
+this.slideshowScript = (function() {
+    let slideElements = [];
+    let currentSlideIndex = 0;
+
+    const videoSources = [
+        "youtube.com",
+        "vimeo.com"
+    ];
+
+    slideElements = detectAllMedia();
+    buildSlideStructure();
+
+    const lbContainer = document.body.querySelector(".fv-lightbox-container");
+    const slideContainer = document.body.querySelector(".fv-slide-image");
+
+    function buildSlideStructure() {
+        const lightboxElement = document.createElement("div");
+        lightboxElement.className = "fv-lightbox-container";
+        lightboxElement.onclick = hideSlideShow;
+
+        const slideshowContainer = document.createElement("div");
+        slideshowContainer.className = "fv-slideshow-container";
+
+        const slideImage = document.createElement("div");
+        slideImage.className = "fv-slide-image";
+
+        const tagPrev = document.createElement("a");
+        tagPrev.className = "fv-prev";
+        tagPrev.textContent = String.fromCharCode(10094);
+        tagPrev.onclick = previousSlide;
+
+        const tagNext = document.createElement("a");
+        tagNext.className = "fv-next";
+        tagNext.textContent = String.fromCharCode(10095);
+        tagNext.onclick = nextSlide;
+
+        slideshowContainer.appendChild(slideImage);
+        slideshowContainer.appendChild(tagPrev);
+        slideshowContainer.appendChild(tagNext);
+
+        lightboxElement.appendChild(slideshowContainer);
+
+        document.body.appendChild(lightboxElement);
+    }
+
+    function hideSlideShow(event) {
+        if (event.target === lbContainer) {
+        lbContainer.style.display = "none";
+        swapSlide();
+        }
+    }
+
+    function revealSlideshow() {
+        swapSlide(slideElements[0]);
+        lbContainer.style.display = "block";
+    }
+
+    function isVideoSourceUrl(url) {
+        let testExp = "";
+        const result = videoSources.some(function(videoSource) {
+            testExp = new RegExp(`^(https?:\/\/)?(www\.)?${videoSource}`);
+            return testExp.test(url);
+        });
+
+        return result;
+    }
+
+    function detectAllMedia() {
+        const selector = "img, video, iframe";
+        // detect all supported elements
+        const mediaElements = document.body.querySelectorAll(selector);
+
+        // iterate thru list and add to array
+
+        mediaElements.forEach(element => {
+            // strip their current classes
+
+            element.className = "";
+            switch (element.tagName) {
+                case "IMG": {
+                    const img = document.createElement("img");
+                    img.setAttribute("src", element.getAttribute("src"));
+                    slideElements.push(img);
+
+                    break;
+                }
+                case "VIDEO": {
+                    const vid = document.createElement("video");
+                    vid.setAttribute("src", element.getAttribute("src"));
+                    vid.setAttribute("controls", true);
+                    slideElements.push(vid);
+
+                    break;
+                }
+                case "IFRAME": {
+                    if (isVideoSourceUrl(element.getAttribute("src"))) {
+                        const iframe = document.createElement("iframe");
+                        iframe.setAttribute("src", element.getAttribute("src"));
+                        iframe.setAttribute("width", 640);
+                        iframe.setAttribute("height", 400);
+                        slideElements.push(iframe);
+                    }
+
+                    break;
+                }
+            }
+        });
+
+        return slideElements;
+    }
+
+    function previousSlide() {
+        moveSlide(-1);
+    }
+
+    function nextSlide() {
+        moveSlide(1);
+    }
+
+    function moveSlide(steps) {
+        let newIndex = currentSlideIndex + steps;
+        if (newIndex > slideElements.length - 1) {
+            newIndex = 0;
+        }
+        if (newIndex < 0) {
+            newIndex = slideElements.length - 1;
+        }
+
+        showSlide(newIndex);
+    }
+
+    function showSlide(slideIndex) {
+        currentSlideIndex = slideIndex;
+        swapSlide(slideElements[slideIndex]);
+    }
+
+    function swapSlide(newSlide) {
+        if (slideContainer.hasChildNodes()) {
+        slideContainer.firstChild.remove();
+        }
+        if (newSlide) {
+        slideContainer.appendChild(newSlide);
+        }
+    }
+
+    communicate.register("openSlide", async (message) => {
+        revealSlideshow();
+
+        return true;
+    });
+})();
+
+

--- a/extension/intents/slideshow/contentScript.js
+++ b/extension/intents/slideshow/contentScript.js
@@ -1,155 +1,150 @@
 /* globals communicate */
 
 this.slideshowScript = (function() {
-    let slideElements = [];
-    let currentSlideIndex = 0;
+  let slideElements = [];
+  let currentSlideIndex = 0;
 
-    const videoSources = [
-        "youtube.com",
-        "vimeo.com"
-    ];
+  const videoSources = ["youtube.com", "vimeo.com"];
 
-    slideElements = detectAllMedia();
-    buildSlideStructure();
+  slideElements = detectAllMedia();
+  buildSlideStructure();
 
-    const lbContainer = document.body.querySelector(".fv-lightbox-container");
-    const slideContainer = document.body.querySelector(".fv-slide-image");
+  const lbContainer = document.body.querySelector(".fv-lightbox-container");
+  const slideContainer = document.body.querySelector(".fv-slide-image");
 
-    function buildSlideStructure() {
-        const lightboxElement = document.createElement("div");
-        lightboxElement.className = "fv-lightbox-container";
-        lightboxElement.onclick = hideSlideShow;
+  function buildSlideStructure() {
+    const lightboxElement = document.createElement("div");
+    lightboxElement.className = "fv-lightbox-container";
+    lightboxElement.onclick = hideSlideShow;
 
-        const slideshowContainer = document.createElement("div");
-        slideshowContainer.className = "fv-slideshow-container";
+    const slideshowContainer = document.createElement("div");
+    slideshowContainer.className = "fv-slideshow-container";
 
-        const slideImage = document.createElement("div");
-        slideImage.className = "fv-slide-image";
+    const slideImage = document.createElement("div");
+    slideImage.className = "fv-slide-image";
 
-        const tagPrev = document.createElement("a");
-        tagPrev.className = "fv-prev";
-        tagPrev.textContent = String.fromCharCode(10094);
-        tagPrev.onclick = previousSlide;
+    const tagPrev = document.createElement("a");
+    tagPrev.className = "fv-prev";
+    tagPrev.textContent = String.fromCharCode(10094);
+    tagPrev.onclick = previousSlide;
 
-        const tagNext = document.createElement("a");
-        tagNext.className = "fv-next";
-        tagNext.textContent = String.fromCharCode(10095);
-        tagNext.onclick = nextSlide;
+    const tagNext = document.createElement("a");
+    tagNext.className = "fv-next";
+    tagNext.textContent = String.fromCharCode(10095);
+    tagNext.onclick = nextSlide;
 
-        slideshowContainer.appendChild(slideImage);
-        slideshowContainer.appendChild(tagPrev);
-        slideshowContainer.appendChild(tagNext);
+    slideshowContainer.appendChild(slideImage);
+    slideshowContainer.appendChild(tagPrev);
+    slideshowContainer.appendChild(tagNext);
 
-        lightboxElement.appendChild(slideshowContainer);
+    lightboxElement.appendChild(slideshowContainer);
 
-        document.body.appendChild(lightboxElement);
+    document.body.appendChild(lightboxElement);
+  }
+
+  function hideSlideShow(event) {
+    if (event.target === lbContainer) {
+      lbContainer.style.display = "none";
+      swapSlide();
     }
+  }
 
-    function hideSlideShow(event) {
-        if (event.target === lbContainer) {
-        lbContainer.style.display = "none";
-        swapSlide();
-        }
-    }
+  function revealSlideshow() {
+    swapSlide(slideElements[0]);
+    lbContainer.style.display = "block";
+  }
 
-    function revealSlideshow() {
-        swapSlide(slideElements[0]);
-        lbContainer.style.display = "block";
-    }
-
-    function isVideoSourceUrl(url) {
-        let testExp = "";
-        const result = videoSources.some(function(videoSource) {
-            testExp = new RegExp(`^(https?:\/\/)?(www\.)?${videoSource}`);
-            return testExp.test(url);
-        });
-
-        return result;
-    }
-
-    function detectAllMedia() {
-        const selector = "img, video, iframe";
-        // detect all supported elements
-        const mediaElements = document.body.querySelectorAll(selector);
-
-        // iterate thru list and add to array
-
-        mediaElements.forEach(element => {
-            // strip their current classes
-
-            element.className = "";
-            switch (element.tagName) {
-                case "IMG": {
-                    const img = document.createElement("img");
-                    img.setAttribute("src", element.getAttribute("src"));
-                    slideElements.push(img);
-
-                    break;
-                }
-                case "VIDEO": {
-                    const vid = document.createElement("video");
-                    vid.setAttribute("src", element.getAttribute("src"));
-                    vid.setAttribute("controls", true);
-                    slideElements.push(vid);
-
-                    break;
-                }
-                case "IFRAME": {
-                    if (isVideoSourceUrl(element.getAttribute("src"))) {
-                        const iframe = document.createElement("iframe");
-                        iframe.setAttribute("src", element.getAttribute("src"));
-                        iframe.setAttribute("width", 640);
-                        iframe.setAttribute("height", 400);
-                        slideElements.push(iframe);
-                    }
-
-                    break;
-                }
-            }
-        });
-
-        return slideElements;
-    }
-
-    function previousSlide() {
-        moveSlide(-1);
-    }
-
-    function nextSlide() {
-        moveSlide(1);
-    }
-
-    function moveSlide(steps) {
-        let newIndex = currentSlideIndex + steps;
-        if (newIndex > slideElements.length - 1) {
-            newIndex = 0;
-        }
-        if (newIndex < 0) {
-            newIndex = slideElements.length - 1;
-        }
-
-        showSlide(newIndex);
-    }
-
-    function showSlide(slideIndex) {
-        currentSlideIndex = slideIndex;
-        swapSlide(slideElements[slideIndex]);
-    }
-
-    function swapSlide(newSlide) {
-        if (slideContainer.hasChildNodes()) {
-        slideContainer.firstChild.remove();
-        }
-        if (newSlide) {
-        slideContainer.appendChild(newSlide);
-        }
-    }
-
-    communicate.register("openSlide", async (message) => {
-        revealSlideshow();
-
-        return true;
+  function isVideoSourceUrl(url) {
+    let testExp = "";
+    const result = videoSources.some(function(videoSource) {
+      testExp = new RegExp(`^(https?:\/\/)?(www\.)?${videoSource}`);
+      return testExp.test(url);
     });
+
+    return result;
+  }
+
+  function detectAllMedia() {
+    const selector = "img, video, iframe";
+    // detect all supported elements
+    const mediaElements = document.body.querySelectorAll(selector);
+
+    // iterate thru list and add to array
+
+    mediaElements.forEach(element => {
+      // strip their current classes
+
+      element.className = "";
+      switch (element.tagName) {
+        case "IMG": {
+          const img = document.createElement("img");
+          img.setAttribute("src", element.getAttribute("src"));
+          slideElements.push(img);
+
+          break;
+        }
+        case "VIDEO": {
+          const vid = document.createElement("video");
+          vid.setAttribute("src", element.getAttribute("src"));
+          vid.setAttribute("controls", true);
+          slideElements.push(vid);
+
+          break;
+        }
+        case "IFRAME": {
+          if (isVideoSourceUrl(element.getAttribute("src"))) {
+            const iframe = document.createElement("iframe");
+            iframe.setAttribute("src", element.getAttribute("src"));
+            iframe.setAttribute("width", 640);
+            iframe.setAttribute("height", 400);
+            slideElements.push(iframe);
+          }
+
+          break;
+        }
+      }
+    });
+
+    return slideElements;
+  }
+
+  function previousSlide() {
+    moveSlide(-1);
+  }
+
+  function nextSlide() {
+    moveSlide(1);
+  }
+
+  function moveSlide(steps) {
+    let newIndex = currentSlideIndex + steps;
+    if (newIndex > slideElements.length - 1) {
+      newIndex = 0;
+    }
+    if (newIndex < 0) {
+      newIndex = slideElements.length - 1;
+    }
+
+    showSlide(newIndex);
+  }
+
+  function showSlide(slideIndex) {
+    currentSlideIndex = slideIndex;
+    swapSlide(slideElements[slideIndex]);
+  }
+
+  function swapSlide(newSlide) {
+    if (slideContainer.hasChildNodes()) {
+      slideContainer.firstChild.remove();
+    }
+    if (newSlide) {
+      slideContainer.appendChild(newSlide);
+    }
+  }
+
+  communicate.register("openSlide", async message => {
+    revealSlideshow();
+
+    return true;
+  });
 })();
-
-

--- a/extension/intents/slideshow/slideshow.js
+++ b/extension/intents/slideshow/slideshow.js
@@ -1,0 +1,24 @@
+import * as intentRunner from "../../background/intentRunner.js";
+import * as content from "../../background/content.js";
+
+const SLIDESHOW_SCRIPT = "/intents/slideshow/contentScript.js";
+const SLIDESHOW_CSS = "/intents/slideshow/contentScript.css";
+
+intentRunner.registerIntent({
+    name: "slideshow.open",
+    async run(context) {
+        const activeTab = await context.activeTab();
+        const activeTabId = activeTab.id;
+        await content.lazyInject(activeTabId, SLIDESHOW_SCRIPT);
+        await browser.tabs.insertCSS(activeTabId, {file: SLIDESHOW_CSS});
+        const success = await browser.tabs.sendMessage(activeTabId, {
+            type: "openSlide"
+        });
+
+        if (!success) {
+            const err = new Error("Could not open slideshow");
+            err.displayMessage = "Could not open slideshow";
+            throw err;
+        }
+    }
+});

--- a/extension/intents/slideshow/slideshow.js
+++ b/extension/intents/slideshow/slideshow.js
@@ -5,20 +5,20 @@ const SLIDESHOW_SCRIPT = "/intents/slideshow/contentScript.js";
 const SLIDESHOW_CSS = "/intents/slideshow/contentScript.css";
 
 intentRunner.registerIntent({
-    name: "slideshow.open",
-    async run(context) {
-        const activeTab = await context.activeTab();
-        const activeTabId = activeTab.id;
-        await content.lazyInject(activeTabId, SLIDESHOW_SCRIPT);
-        await browser.tabs.insertCSS(activeTabId, {file: SLIDESHOW_CSS});
-        const success = await browser.tabs.sendMessage(activeTabId, {
-            type: "openSlide"
-        });
+  name: "slideshow.open",
+  async run(context) {
+    const activeTab = await context.activeTab();
+    const activeTabId = activeTab.id;
+    await content.lazyInject(activeTabId, SLIDESHOW_SCRIPT);
+    await browser.tabs.insertCSS(activeTabId, { file: SLIDESHOW_CSS });
+    const success = await browser.tabs.sendMessage(activeTabId, {
+      type: "openSlide",
+    });
 
-        if (!success) {
-            const err = new Error("Could not open slideshow");
-            err.displayMessage = "Could not open slideshow";
-            throw err;
-        }
+    if (!success) {
+      const err = new Error("Could not open slideshow");
+      err.displayMessage = "Could not open slideshow";
+      throw err;
     }
+  },
 });

--- a/extension/intents/slideshow/slideshow.toml
+++ b/extension/intents/slideshow/slideshow.toml
@@ -1,0 +1,12 @@
+[slideshow.open]
+description = "Opens the slideshow"
+match = '''
+    (open | display | launch | start) (the |) (slideshow | slide shoe)
+'''
+
+[[slideshow.open.example]]
+phrase = "Open slideshow"
+
+[[slideshow.open.example]]
+phrase = "Launch the slideshow"
+test = true


### PR DESCRIPTION
Before submitting a final PR, please:

- [ ] Run `npm test` on your machine
- [X] Run `npm run format` to keep code formatted consistently
- [X] Reference the issue you are fixing in at least one of your commit messages, as `Fixes #X`

Fixes #1115 
This is a first draft for the intent to start a slideshow of images and videos in a tab. Slideshow design is minimal, but may need more work. Tests are currently failing locally after a recent fork sync, particularly selenium tests I think. @ianb please kindly review.
