### PR TITLE
Create start slideshow intent

### DIFF
--- a/extension/intents/music/music.js
+++ b/extension/intents/music/music.js
@@ -97,7 +97,9 @@ intentRunner.registerIntent({
   async run(context) {
     for (const ServiceClass of Object.values(SERVICES)) {
       const service = new ServiceClass(context);
-      await service.pauseAny({exceptTabId: (await browserUtil.activeTab()).id});
+      await service.pauseAny({
+        exceptTabId: (await browserUtil.activeTab()).id,
+      });
     }
     const service = await getService(context, { lookAtCurrentTab: true });
     await service.unpause();

--- a/extension/intents/search/search.js
+++ b/extension/intents/search/search.js
@@ -304,6 +304,13 @@ intentRunner.registerIntent({
     await performSearch(context.slots.query);
     const searchInfo = await callScript({ type: "searchResultInfo" });
     searchInfo.query = context.slots.query;
+
+    if (!searchInfo.searchResults) {
+      const e = new Error("No result found for " + searchInfo.query);
+      e.displayMessage = "No result found for " + searchInfo.query;
+      throw e;
+    }
+
     if (searchInfo.hasCard || searchInfo.hasSidebarCard) {
       const card = await callScript({ type: "cardImage" });
       context.keepPopup();

--- a/extension/intents/slideshow/contentScript.css
+++ b/extension/intents/slideshow/contentScript.css
@@ -76,14 +76,14 @@
   padding: 12px;
 }
 
-.fv-view-gallery, 
+.fv-view-gallery,
 .fv-view-slide {
   cursor: pointer;
   width: auto;
   padding: 2px 10px;
   color: white;
   font-size: 24px;
-  transition: 0.6s ease;    
+  transition: 0.6s ease;
   user-select: none;
   display: table-cell;
   float: left;
@@ -94,14 +94,14 @@
   font-size: 28px;
 }
 
-.fv-view-gallery{
+.fv-view-gallery {
   padding: 5px 10px;
 }
 
 .fv-next:hover,
 .fv-prev:hover,
 .fv-close:hover,
-.fv-view-gallery:hover, 
+.fv-view-gallery:hover,
 .fv-view-slide:hover {
   background-color: rgba(0, 0, 0, 0.8);
 }
@@ -119,7 +119,7 @@
 .fv-image-thumbnail {
   width: 100%;
   height: 100%;
-  object-fit: contain;  
+  object-fit: contain;
   cursor: pointer;
 }
 
@@ -130,7 +130,7 @@
 
 .fv-thumbnail:hover {
   background-color: rgb(224, 212, 212);
-  border: 10px solid whitesmoke;;
+  border: 10px solid whitesmoke;
 }
 
 .fv-iframe-thumbnail-container {

--- a/extension/intents/slideshow/contentScript.css
+++ b/extension/intents/slideshow/contentScript.css
@@ -1,67 +1,68 @@
 .fv-lightbox-container {
-    height: 100%;
-    width: 100%;
-    background-color: rgba(0,0,0,0.8);
-    z-index: 100;
-    position: fixed;
-    top:0;
-    left: 0;
-    display: none;
+  height: 100%;
+  width: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  z-index: 100;
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: none;
 }
 
-.fv-slideshow-container {  
-    display: flex;     
-    position: relative;
-    height: 80%;    
-    width: 60%;
-    border: 12px solid whitesmoke;
-    border-radius: 7px;
-    background-color: dimgray; 
-    margin: 3% auto; 
-    justify-content: center;
+.fv-slideshow-container {
+  display: flex;
+  position: relative;
+  height: 80%;
+  width: 60%;
+  border: 12px solid whitesmoke;
+  border-radius: 7px;
+  background-color: dimgray;
+  margin: 3% auto;
+  justify-content: center;
 }
 
 .fv-slide-image img {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;  
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .fv-slide-image video {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .fv-slide-image iframe {
-    margin-top: 5%;
+  margin-top: 5%;
 }
 
-.fv-prev, .fv-next {
-    cursor: pointer;
-    position: absolute;
-    top: 50%;
-    width: auto;
-    margin-top: -22px;
-    padding: 16px;
-    color: white;
-    font-weight: bold;
-    font-size: 18px;
-    transition: 0.6s ease;    
-    user-select: none;
+.fv-prev,
+.fv-next {
+  cursor: pointer;
+  position: absolute;
+  top: 50%;
+  width: auto;
+  margin-top: -22px;
+  padding: 16px;
+  color: white;
+  font-weight: bold;
+  font-size: 18px;
+  transition: 0.6s ease;
+  user-select: none;
 }
 
 .fv-next {
-    right: 0;
-    border-radius: 3px 0 0 3px;
+  right: 0;
+  border-radius: 3px 0 0 3px;
 }
 
 .fv-prev {
-    left: 0;
-    border-radius:  0 3px 3px 0;
+  left: 0;
+  border-radius: 0 3px 3px 0;
 }
 
-.fv-next:hover, .fv-prev:hover {
-    background-color: rgba(0,0,0,0.8);
+.fv-next:hover,
+.fv-prev:hover {
+  background-color: rgba(0, 0, 0, 0.8);
 }

--- a/extension/intents/slideshow/contentScript.css
+++ b/extension/intents/slideshow/contentScript.css
@@ -12,13 +12,24 @@
 .fv-slideshow-container {
   display: flex;
   position: relative;
-  height: 80%;
-  width: 60%;
-  border: 12px solid whitesmoke;
-  border-radius: 7px;
-  background-color: dimgray;
-  margin: 3% auto;
+  height: 100%;
+  width: 100%;
+  border: none;
+  background-color: rgb(38, 38, 39);
   justify-content: center;
+}
+
+.fv-slide-image {
+  width: 100%;
+  height: 100%;
+}
+
+.fv-navbar {
+  position: fixed;
+  top: 0;
+  z-index: 10;
+  background-color: rgba(0, 0, 0, 0.2);
+  width: 100%;
 }
 
 .fv-slide-image img {
@@ -34,35 +45,28 @@
 }
 
 .fv-slide-image iframe {
-  margin-top: 5%;
+  object-fit: contain;
 }
 
 .fv-prev,
-.fv-next {
+.fv-next,
+.fv-close {
   cursor: pointer;
-  position: absolute;
-  top: 50%;
   width: auto;
-  margin-top: -22px;
-  padding: 16px;
+  padding: 10px;
   color: white;
   font-weight: bold;
-  font-size: 18px;
+  font-size: 16px;
   transition: 0.6s ease;
   user-select: none;
-}
-
-.fv-next {
-  right: 0;
-  border-radius: 3px 0 0 3px;
-}
-
-.fv-prev {
-  left: 0;
-  border-radius: 0 3px 3px 0;
+  display: table-cell;
+  float: right;
+  vertical-align: middle;
+  text-decoration: none;
 }
 
 .fv-next:hover,
-.fv-prev:hover {
+.fv-prev:hover,
+.fv-close:hover {
   background-color: rgba(0, 0, 0, 0.8);
 }

--- a/extension/intents/slideshow/contentScript.css
+++ b/extension/intents/slideshow/contentScript.css
@@ -61,10 +61,10 @@
 .fv-close {
   cursor: pointer;
   width: auto;
-  padding: 10px;
+  padding: 12px;
   color: white;
   font-weight: bold;
-  font-size: 16px;
+  font-size: 18px;
   transition: 0.6s ease;
   user-select: none;
   display: table-cell;
@@ -74,7 +74,7 @@
 }
 
 .fv-close {
-  padding: 12px;
+  padding: 13px;
 }
 
 .fv-view-gallery,
@@ -82,23 +82,16 @@
 .fv-update-gallery,
 .fv-reload-gallery {
   cursor: pointer;
-  width: auto;
-  padding: 2px 10px;
+  width: 20px;
+  padding: 5px 10px;
   color: white;
-  font-size: 24px;
+  font-size: 28px;
   transition: 0.6s ease;
   user-select: none;
-  display: table-cell;
+  display: flex;
   float: left;
-  vertical-align: middle;
-}
-
-.fv-view-slide {
-  font-size: 28px;
-}
-
-.fv-view-gallery {
-  padding: 5px 10px;
+  align-items: center;
+  justify-content: space-evenly;
 }
 
 .fv-next:hover,
@@ -108,7 +101,8 @@
 .fv-view-slide:hover,
 .fv-update-gallery:hover,
 .fv-reload-gallery:hover {
-  background-color: rgba(0, 0, 0, 0.8);
+  background-color: rgb(224, 213, 213);
+  color: black;
 }
 
 .fv-thumbnail-gallery {

--- a/extension/intents/slideshow/contentScript.css
+++ b/extension/intents/slideshow/contentScript.css
@@ -6,7 +6,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  display: none;
+  display: block;
 }
 
 .fv-slideshow-container {

--- a/extension/intents/slideshow/contentScript.css
+++ b/extension/intents/slideshow/contentScript.css
@@ -14,10 +14,11 @@
   height: 100%;
   overflow-y: scroll;
   background-color: rgb(38, 38, 39);
+  display: none;
 }
 
 .fv-slideshow-container {
-  display: none;
+  display: flex;
   position: relative;
   height: 100%;
   width: 100%;

--- a/extension/intents/slideshow/contentScript.css
+++ b/extension/intents/slideshow/contentScript.css
@@ -1,0 +1,67 @@
+.fv-lightbox-container {
+    height: 100%;
+    width: 100%;
+    background-color: rgba(0,0,0,0.8);
+    z-index: 100;
+    position: fixed;
+    top:0;
+    left: 0;
+    display: none;
+}
+
+.fv-slideshow-container {  
+    display: flex;     
+    position: relative;
+    height: 80%;    
+    width: 60%;
+    border: 12px solid whitesmoke;
+    border-radius: 7px;
+    background-color: dimgray; 
+    margin: 3% auto; 
+    justify-content: center;
+}
+
+.fv-slide-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;  
+}
+
+.fv-slide-image video {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+
+}
+
+.fv-slide-image iframe {
+    margin-top: 5%;
+}
+
+.fv-prev, .fv-next {
+    cursor: pointer;
+    position: absolute;
+    top: 50%;
+    width: auto;
+    margin-top: -22px;
+    padding: 16px;
+    color: white;
+    font-weight: bold;
+    font-size: 18px;
+    transition: 0.6s ease;    
+    user-select: none;
+}
+
+.fv-next {
+    right: 0;
+    border-radius: 3px 0 0 3px;
+}
+
+.fv-prev {
+    left: 0;
+    border-radius:  0 3px 3px 0;
+}
+
+.fv-next:hover, .fv-prev:hover {
+    background-color: rgba(0,0,0,0.8);
+}

--- a/extension/intents/slideshow/contentScript.js
+++ b/extension/intents/slideshow/contentScript.js
@@ -1,0 +1,155 @@
+/* globals communicate */
+
+this.slideshowScript = (function() {
+    let slideElements = [];
+    let currentSlideIndex = 0;
+
+    const videoSources = [
+        "youtube.com",
+        "vimeo.com"
+    ];
+
+    slideElements = detectAllMedia();
+    buildSlideStructure();
+
+    const lbContainer = document.body.querySelector(".fv-lightbox-container");
+    const slideContainer = document.body.querySelector(".fv-slide-image");
+
+    function buildSlideStructure() {
+        const lightboxElement = document.createElement("div");
+        lightboxElement.className = "fv-lightbox-container";
+        lightboxElement.onclick = hideSlideShow;
+
+        const slideshowContainer = document.createElement("div");
+        slideshowContainer.className = "fv-slideshow-container";
+
+        const slideImage = document.createElement("div");
+        slideImage.className = "fv-slide-image";
+
+        const tagPrev = document.createElement("a");
+        tagPrev.className = "fv-prev";
+        tagPrev.textContent = String.fromCharCode(10094);
+        tagPrev.onclick = previousSlide;
+
+        const tagNext = document.createElement("a");
+        tagNext.className = "fv-next";
+        tagNext.textContent = String.fromCharCode(10095);
+        tagNext.onclick = nextSlide;
+
+        slideshowContainer.appendChild(slideImage);
+        slideshowContainer.appendChild(tagPrev);
+        slideshowContainer.appendChild(tagNext);
+
+        lightboxElement.appendChild(slideshowContainer);
+
+        document.body.appendChild(lightboxElement);
+    }
+
+    function hideSlideShow(event) {
+        if (event.target === lbContainer) {
+        lbContainer.style.display = "none";
+        swapSlide();
+        }
+    }
+
+    function revealSlideshow() {
+        swapSlide(slideElements[0]);
+        lbContainer.style.display = "block";
+    }
+
+    function isVideoSourceUrl(url) {
+        let testExp = "";
+        const result = videoSources.some(function(videoSource) {
+            testExp = new RegExp(`^(https?:\/\/)?(www\.)?${videoSource}`);
+            return testExp.test(url);
+        });
+
+        return result;
+    }
+
+    function detectAllMedia() {
+        const selector = "img, video, iframe";
+        // detect all supported elements
+        const mediaElements = document.body.querySelectorAll(selector);
+
+        // iterate thru list and add to array
+
+        mediaElements.forEach(element => {
+            // strip their current classes
+
+            element.className = "";
+            switch (element.tagName) {
+                case "IMG": {
+                    const img = document.createElement("img");
+                    img.setAttribute("src", element.getAttribute("src"));
+                    slideElements.push(img);
+
+                    break;
+                }
+                case "VIDEO": {
+                    const vid = document.createElement("video");
+                    vid.setAttribute("src", element.getAttribute("src"));
+                    vid.setAttribute("controls", true);
+                    slideElements.push(vid);
+
+                    break;
+                }
+                case "IFRAME": {
+                    if (isVideoSourceUrl(element.getAttribute("src"))) {
+                        const iframe = document.createElement("iframe");
+                        iframe.setAttribute("src", element.getAttribute("src"));
+                        iframe.setAttribute("width", 640);
+                        iframe.setAttribute("height", 400);
+                        slideElements.push(iframe);
+                    }
+
+                    break;
+                }
+            }
+        });
+
+        return slideElements;
+    }
+
+    function previousSlide() {
+        moveSlide(-1);
+    }
+
+    function nextSlide() {
+        moveSlide(1);
+    }
+
+    function moveSlide(steps) {
+        let newIndex = currentSlideIndex + steps;
+        if (newIndex > slideElements.length - 1) {
+            newIndex = 0;
+        }
+        if (newIndex < 0) {
+            newIndex = slideElements.length - 1;
+        }
+
+        showSlide(newIndex);
+    }
+
+    function showSlide(slideIndex) {
+        currentSlideIndex = slideIndex;
+        swapSlide(slideElements[slideIndex]);
+    }
+
+    function swapSlide(newSlide) {
+        if (slideContainer.hasChildNodes()) {
+        slideContainer.firstChild.remove();
+        }
+        if (newSlide) {
+        slideContainer.appendChild(newSlide);
+        }
+    }
+
+    communicate.register("openSlide", async (message) => {
+        revealSlideshow();
+
+        return true;
+    });
+})();
+
+

--- a/extension/intents/slideshow/contentScript.js
+++ b/extension/intents/slideshow/contentScript.js
@@ -12,14 +12,18 @@ this.slideshowScript = (function() {
   const videoSources = ["youtube.com", "vimeo.com"];
   buildSlideStructure();
 
-  function buildThumbnailGallery({fromIndex = -1, rebuild = false} = {}) {
+  function buildThumbnailGallery({ fromIndex = -1, rebuild = false } = {}) {
     let thumbnailElement, thumbnail;
 
     if (rebuild) {
       galleryElements.splice(0, galleryElements.length);
     }
 
-    for (let elementIndex = 0; elementIndex < slideElements.length; elementIndex++) {
+    for (
+      let elementIndex = 0;
+      elementIndex < slideElements.length;
+      elementIndex++
+    ) {
       if (fromIndex >= elementIndex) {
         continue;
       }
@@ -125,7 +129,10 @@ this.slideshowScript = (function() {
 
     iframeContainer.addEventListener("load", function() {
       // security check to confirm src
-      if (iframeContainer.src !== browser.runtime.getURL("intents/slideshow/slideshow.html")) {
+      if (
+        iframeContainer.src !==
+        browser.runtime.getURL("intents/slideshow/slideshow.html")
+      ) {
         const err = new Error("Iframe source is invalid");
         err.displayMessage = "Iframe source is invalid";
         throw err;
@@ -143,7 +150,7 @@ this.slideshowScript = (function() {
             nextSlide();
             break;
           }
-          case "Escape" : {
+          case "Escape": {
             hideSlideShow(null);
             break;
           }
@@ -213,11 +220,13 @@ this.slideshowScript = (function() {
       tagUpdateGallery.className = "fv-update-gallery";
       tagUpdateGallery.textContent = String.fromCharCode(8635);
       tagUpdateGallery.onclick = updateMediaElements;
+      tagUpdateGallery.title = "Update Gallery with New Images";
 
       const tagRebuildGallery = document.createElement("a");
       tagRebuildGallery.className = "fv-reload-gallery";
       tagRebuildGallery.textContent = String.fromCharCode(8409);
       tagRebuildGallery.onclick = rebuildMediaElements;
+      tagRebuildGallery.title = "Reload Gallery";
 
       // images and video container
       slideContainer = iframeDoc.createElement("div");
@@ -257,7 +266,7 @@ this.slideshowScript = (function() {
       window.addEventListener("resize", function() {
         iframeContainer.height = document.documentElement.clientHeight;
         iframeContainer.width = document.documentElement.clientWidth;
-        if (slideContainer.hasChildNodes()) {
+        if (slideContainer && slideContainer.hasChildNodes()) {
           if (slideContainer.firstChild.tagName === "IFRAME") {
             slideContainer.firstChild.setAttribute(
               "width",
@@ -296,7 +305,7 @@ this.slideshowScript = (function() {
     return result;
   }
 
-  function detectAllMedia({fromIndex = -1, rebuild = false} = {}) {
+  function detectAllMedia({ fromIndex = -1, rebuild = false } = {}) {
     const selector = "img, video, iframe";
     // detect all supported elements
     const mediaElements = document.body.querySelectorAll(selector);
@@ -307,7 +316,11 @@ this.slideshowScript = (function() {
     }
 
     // iterate thru list and add to array
-    for (let elementIndex = 0; elementIndex < mediaElements.length; elementIndex++) {
+    for (
+      let elementIndex = 0;
+      elementIndex < mediaElements.length;
+      elementIndex++
+    ) {
       if (fromIndex >= elementIndex) {
         continue;
       }
@@ -338,8 +351,6 @@ this.slideshowScript = (function() {
           } else if (element.hasAttribute("data-lazy-src")) {
             img.setAttribute("src", element.getAttribute("data-lazy-src"));
           }
-
-
 
           slideElements.push(img);
 
@@ -417,6 +428,9 @@ this.slideshowScript = (function() {
   }
 
   function swapSlide(newSlide) {
+    if (!slideContainer) {
+      return;
+    }
     if (slideContainer.hasChildNodes()) {
       slideContainer.firstChild.remove();
     }
@@ -430,22 +444,28 @@ this.slideshowScript = (function() {
     }
   }
 
+  // update gallery for pages with infinite scroll
   function updateMediaElements() {
     // detect media from the last index stopped
-    detectAllMedia({fromIndex: lastElementIndex});
-    buildThumbnailGallery({fromIndex: lastGalleryIndex});
+    detectAllMedia({ fromIndex: lastElementIndex });
+    buildThumbnailGallery({ fromIndex: lastGalleryIndex });
 
     // append elements to gallery
-    for (let index = lastGalleryIndex + 1; index < galleryElements.length; index++) {
+    for (
+      let index = lastGalleryIndex + 1;
+      index < galleryElements.length;
+      index++
+    ) {
       const element = galleryElements[index];
       thumbnailGallery.append(element);
     }
   }
 
+  // full gallery reload to help with lazy loaded sites or render errors
   function rebuildMediaElements() {
     // detect media from the last index stopped
-    detectAllMedia({rebuild: true});
-    buildThumbnailGallery({rebuild: true});
+    detectAllMedia({ rebuild: true });
+    buildThumbnailGallery({ rebuild: true });
 
     // empty gallery
     while (thumbnailGallery.hasChildNodes()) {

--- a/extension/intents/slideshow/contentScript.js
+++ b/extension/intents/slideshow/contentScript.js
@@ -101,7 +101,7 @@ this.slideshowScript = (function() {
     iframeContainer.style.position = "fixed";
     iframeContainer.style.top = 0;
     iframeContainer.style.left = 0;
-    iframeContainer.style.zIndex = 100;
+    iframeContainer.style.zIndex = 99999999999;
 
     document.body.appendChild(iframeContainer);
 

--- a/extension/intents/slideshow/contentScript.js
+++ b/extension/intents/slideshow/contentScript.js
@@ -94,6 +94,9 @@ this.slideshowScript = (function() {
   function buildSlideStructure() {
     // create iframe element
     iframeContainer = document.createElement("iframe");
+    iframeContainer.src = browser.runtime.getURL(
+      "intents/slideshow/slideshow.html"
+    );
     iframeContainer.className = "fv-slideshow-frame";
     iframeContainer.height = document.documentElement.clientHeight;
     iframeContainer.width = document.documentElement.clientWidth;

--- a/extension/intents/slideshow/contentScript.js
+++ b/extension/intents/slideshow/contentScript.js
@@ -17,7 +17,8 @@ this.slideshowScript = (function() {
 
       switch (element.tagName) {
         case "VIDEO": {
-          thumbnailElement.className = "fv-image-thumbnail-container fv-thumbnail";
+          thumbnailElement.className =
+            "fv-image-thumbnail-container fv-thumbnail";
 
           thumbnail = iframeDoc.createElement(element.tagName);
           thumbnail.className = "fv-image-thumbnail";
@@ -31,7 +32,8 @@ this.slideshowScript = (function() {
           break;
         }
         case "IMG": {
-          thumbnailElement.className = "fv-image-thumbnail-container fv-thumbnail";
+          thumbnailElement.className =
+            "fv-image-thumbnail-container fv-thumbnail";
 
           thumbnail = iframeDoc.createElement(element.tagName);
           thumbnail.className = "fv-image-thumbnail";
@@ -42,7 +44,8 @@ this.slideshowScript = (function() {
           break;
         }
         case "IFRAME": {
-          thumbnailElement.className = "fv-iframe-thumbnail-container fv-thumbnail";
+          thumbnailElement.className =
+            "fv-iframe-thumbnail-container fv-thumbnail";
 
           iframeBlocker = iframeDoc.createElement("div");
           iframeBlocker.style.position = "absolute";
@@ -110,7 +113,9 @@ this.slideshowScript = (function() {
       const iframeLink = iframeDoc.createElement("link");
       iframeLink.type = "text/css";
       iframeLink.rel = "stylesheet";
-      iframeLink.href = browser.runtime.getURL("intents/slideshow/contentScript.css");
+      iframeLink.href = browser.runtime.getURL(
+        "intents/slideshow/contentScript.css"
+      );
       iframeDoc.head.appendChild(iframeLink);
 
       // containers for slideshow and gallery

--- a/extension/intents/slideshow/contentScript.js
+++ b/extension/intents/slideshow/contentScript.js
@@ -270,6 +270,21 @@ this.slideshowScript = (function() {
           } else {
             img.setAttribute("src", element.getAttribute("src"));
           }
+
+          // bypass jquery lazy-loading
+          if (/lazy/.test(element.className)) {
+            if (element.hasAttribute("data-lazy-src")) {
+              img.setAttribute("src", element.getAttribute("data-lazy-src"));
+            }
+            if (element.hasAttribute("data-src")) {
+              img.setAttribute("src", element.getAttribute("data-lazy-src"));
+            }
+          } else if (element.hasAttribute("data-lazy-src")) {
+            img.setAttribute("src", element.getAttribute("data-lazy-src"));
+          }
+
+
+
           slideElements.push(img);
 
           break;

--- a/extension/intents/slideshow/contentScript.js
+++ b/extension/intents/slideshow/contentScript.js
@@ -1,155 +1,150 @@
 /* globals communicate */
 
 this.slideshowScript = (function() {
-    let slideElements = [];
-    let currentSlideIndex = 0;
+  let slideElements = [];
+  let currentSlideIndex = 0;
 
-    const videoSources = [
-        "youtube.com",
-        "vimeo.com"
-    ];
+  const videoSources = ["youtube.com", "vimeo.com"];
 
-    slideElements = detectAllMedia();
-    buildSlideStructure();
+  slideElements = detectAllMedia();
+  buildSlideStructure();
 
-    const lbContainer = document.body.querySelector(".fv-lightbox-container");
-    const slideContainer = document.body.querySelector(".fv-slide-image");
+  const lbContainer = document.body.querySelector(".fv-lightbox-container");
+  const slideContainer = document.body.querySelector(".fv-slide-image");
 
-    function buildSlideStructure() {
-        const lightboxElement = document.createElement("div");
-        lightboxElement.className = "fv-lightbox-container";
-        lightboxElement.onclick = hideSlideShow;
+  function buildSlideStructure() {
+    const lightboxElement = document.createElement("div");
+    lightboxElement.className = "fv-lightbox-container";
+    lightboxElement.onclick = hideSlideShow;
 
-        const slideshowContainer = document.createElement("div");
-        slideshowContainer.className = "fv-slideshow-container";
+    const slideshowContainer = document.createElement("div");
+    slideshowContainer.className = "fv-slideshow-container";
 
-        const slideImage = document.createElement("div");
-        slideImage.className = "fv-slide-image";
+    const slideImage = document.createElement("div");
+    slideImage.className = "fv-slide-image";
 
-        const tagPrev = document.createElement("a");
-        tagPrev.className = "fv-prev";
-        tagPrev.textContent = String.fromCharCode(10094);
-        tagPrev.onclick = previousSlide;
+    const tagPrev = document.createElement("a");
+    tagPrev.className = "fv-prev";
+    tagPrev.textContent = String.fromCharCode(10094);
+    tagPrev.onclick = previousSlide;
 
-        const tagNext = document.createElement("a");
-        tagNext.className = "fv-next";
-        tagNext.textContent = String.fromCharCode(10095);
-        tagNext.onclick = nextSlide;
+    const tagNext = document.createElement("a");
+    tagNext.className = "fv-next";
+    tagNext.textContent = String.fromCharCode(10095);
+    tagNext.onclick = nextSlide;
 
-        slideshowContainer.appendChild(slideImage);
-        slideshowContainer.appendChild(tagPrev);
-        slideshowContainer.appendChild(tagNext);
+    slideshowContainer.appendChild(slideImage);
+    slideshowContainer.appendChild(tagPrev);
+    slideshowContainer.appendChild(tagNext);
 
-        lightboxElement.appendChild(slideshowContainer);
+    lightboxElement.appendChild(slideshowContainer);
 
-        document.body.appendChild(lightboxElement);
+    document.body.appendChild(lightboxElement);
+  }
+
+  function hideSlideShow(event) {
+    if (event.target === lbContainer) {
+      lbContainer.style.display = "none";
+      swapSlide();
     }
+  }
 
-    function hideSlideShow(event) {
-        if (event.target === lbContainer) {
-        lbContainer.style.display = "none";
-        swapSlide();
-        }
-    }
+  function revealSlideshow() {
+    swapSlide(slideElements[0]);
+    lbContainer.style.display = "block";
+  }
 
-    function revealSlideshow() {
-        swapSlide(slideElements[0]);
-        lbContainer.style.display = "block";
-    }
-
-    function isVideoSourceUrl(url) {
-        let testExp = "";
-        const result = videoSources.some(function(videoSource) {
-            testExp = new RegExp(`^(https?:\/\/)?(www\.)?${videoSource}`);
-            return testExp.test(url);
-        });
-
-        return result;
-    }
-
-    function detectAllMedia() {
-        const selector = "img, video, iframe";
-        // detect all supported elements
-        const mediaElements = document.body.querySelectorAll(selector);
-
-        // iterate thru list and add to array
-
-        mediaElements.forEach(element => {
-            // strip their current classes
-
-            element.className = "";
-            switch (element.tagName) {
-                case "IMG": {
-                    const img = document.createElement("img");
-                    img.setAttribute("src", element.getAttribute("src"));
-                    slideElements.push(img);
-
-                    break;
-                }
-                case "VIDEO": {
-                    const vid = document.createElement("video");
-                    vid.setAttribute("src", element.getAttribute("src"));
-                    vid.setAttribute("controls", true);
-                    slideElements.push(vid);
-
-                    break;
-                }
-                case "IFRAME": {
-                    if (isVideoSourceUrl(element.getAttribute("src"))) {
-                        const iframe = document.createElement("iframe");
-                        iframe.setAttribute("src", element.getAttribute("src"));
-                        iframe.setAttribute("width", 640);
-                        iframe.setAttribute("height", 400);
-                        slideElements.push(iframe);
-                    }
-
-                    break;
-                }
-            }
-        });
-
-        return slideElements;
-    }
-
-    function previousSlide() {
-        moveSlide(-1);
-    }
-
-    function nextSlide() {
-        moveSlide(1);
-    }
-
-    function moveSlide(steps) {
-        let newIndex = currentSlideIndex + steps;
-        if (newIndex > slideElements.length - 1) {
-            newIndex = 0;
-        }
-        if (newIndex < 0) {
-            newIndex = slideElements.length - 1;
-        }
-
-        showSlide(newIndex);
-    }
-
-    function showSlide(slideIndex) {
-        currentSlideIndex = slideIndex;
-        swapSlide(slideElements[slideIndex]);
-    }
-
-    function swapSlide(newSlide) {
-        if (slideContainer.hasChildNodes()) {
-        slideContainer.firstChild.remove();
-        }
-        if (newSlide) {
-        slideContainer.appendChild(newSlide);
-        }
-    }
-
-    communicate.register("openSlide", async (message) => {
-        revealSlideshow();
-
-        return true;
+  function isVideoSourceUrl(url) {
+    let testExp = "";
+    const result = videoSources.some(function(videoSource) {
+      testExp = new RegExp(`^(https?:\/\/)?(www\.)?${videoSource}`);
+      return testExp.test(url);
     });
+
+    return result;
+  }
+
+  function detectAllMedia() {
+    const selector = "img, video, iframe";
+    // detect all supported elements
+    const mediaElements = document.body.querySelectorAll(selector);
+
+    // iterate thru list and add to array
+
+    mediaElements.forEach(element => {
+      // strip their current classes
+
+      element.className = "";
+      switch (element.tagName) {
+        case "IMG": {
+          const img = document.createElement("img");
+          img.setAttribute("src", element.getAttribute("src"));
+          slideElements.push(img);
+
+          break;
+        }
+        case "VIDEO": {
+          const vid = document.createElement("video");
+          vid.setAttribute("src", element.getAttribute("src"));
+          vid.setAttribute("controls", true);
+          slideElements.push(vid);
+
+          break;
+        }
+        case "IFRAME": {
+          if (isVideoSourceUrl(element.getAttribute("src"))) {
+            const iframe = document.createElement("iframe");
+            iframe.setAttribute("src", element.getAttribute("src"));
+            iframe.setAttribute("width", 640);
+            iframe.setAttribute("height", 400);
+            slideElements.push(iframe);
+          }
+
+          break;
+        }
+      }
+    });
+
+    return slideElements;
+  }
+
+  function previousSlide() {
+    moveSlide(-1);
+  }
+
+  function nextSlide() {
+    moveSlide(1);
+  }
+
+  function moveSlide(steps) {
+    let newIndex = currentSlideIndex + steps;
+    if (newIndex > slideElements.length - 1) {
+      newIndex = 0;
+    }
+    if (newIndex < 0) {
+      newIndex = slideElements.length - 1;
+    }
+
+    showSlide(newIndex);
+  }
+
+  function showSlide(slideIndex) {
+    currentSlideIndex = slideIndex;
+    swapSlide(slideElements[slideIndex]);
+  }
+
+  function swapSlide(newSlide) {
+    if (slideContainer.hasChildNodes()) {
+      slideContainer.firstChild.remove();
+    }
+    if (newSlide) {
+      slideContainer.appendChild(newSlide);
+    }
+  }
+
+  communicate.register("openSlide", async message => {
+    revealSlideshow();
+
+    return true;
+  });
 })();
-
-

--- a/extension/intents/slideshow/contentScript.js
+++ b/extension/intents/slideshow/contentScript.js
@@ -109,6 +109,13 @@ this.slideshowScript = (function() {
     document.body.appendChild(iframeContainer);
 
     iframeContainer.addEventListener("load", function() {
+      // security check to confirm src
+      if (iframeContainer.src !== browser.runtime.getURL("intents/slideshow/slideshow.html")) {
+        const err = new Error("Iframe source is invalid");
+        err.displayMessage = "Iframe source is invalid";
+        throw err;
+      }
+
       // contentWindow is first accessible here
       iframeDoc = iframeContainer.contentWindow.document;
 

--- a/extension/intents/slideshow/contentScript.js
+++ b/extension/intents/slideshow/contentScript.js
@@ -260,8 +260,16 @@ this.slideshowScript = (function() {
       element.className = "";
       switch (element.tagName) {
         case "IMG": {
+          if (element.clientHeight < 200 || element.clientWidth < 200) {
+            break;
+          }
+
           const img = iframeDoc.createElement("img");
-          img.setAttribute("src", element.getAttribute("src"));
+          if (/^\/\//.test(element.getAttribute("src"))) {
+            img.setAttribute("src", "https:" + element.getAttribute("src"));
+          } else {
+            img.setAttribute("src", element.getAttribute("src"));
+          }
           slideElements.push(img);
 
           break;

--- a/extension/intents/slideshow/contentScript.js
+++ b/extension/intents/slideshow/contentScript.js
@@ -118,6 +118,22 @@ this.slideshowScript = (function() {
 
       // contentWindow is first accessible here
       iframeDoc = iframeContainer.contentWindow.document;
+      iframeDoc.addEventListener("keyup", function(event) {
+        switch (event.key) {
+          case "ArrowLeft": {
+            previousSlide();
+            break;
+          }
+          case "ArrowRight": {
+            nextSlide();
+            break;
+          }
+          case "Escape" : {
+            hideSlideShow(null);
+            break;
+          }
+        }
+      });
 
       // add css file link in header
       const iframeLink = iframeDoc.createElement("link");
@@ -152,26 +168,31 @@ this.slideshowScript = (function() {
       tagClose.className = "fv-close";
       tagClose.textContent = String.fromCharCode(0x274c);
       tagClose.addEventListener("click", hideSlideShow);
+      tagClose.title = "Close Slideshow";
 
       const tagPrev = iframeDoc.createElement("a");
       tagPrev.className = "fv-prev";
       tagPrev.textContent = String.fromCharCode(10094);
       tagPrev.addEventListener("click", previousSlide);
+      tagPrev.title = "Previous Slide";
 
       const tagNext = iframeDoc.createElement("a");
       tagNext.className = "fv-next";
       tagNext.textContent = String.fromCharCode(10095);
       tagNext.addEventListener("click", nextSlide);
+      tagNext.title = "Next Slide";
 
       const tagViewSlide = document.createElement("a");
       tagViewSlide.className = "fv-view-slide";
       tagViewSlide.textContent = String.fromCharCode(10696);
       tagViewSlide.onclick = toggleGallery;
+      tagViewSlide.title = "View Slide";
 
       const tagViewGallery = document.createElement("a");
       tagViewGallery.className = "fv-view-gallery";
       tagViewGallery.textContent = String.fromCharCode(9638);
       tagViewGallery.onclick = toggleGallery;
+      tagViewGallery.title = "View Gallery";
 
       // images and video container
       slideContainer = iframeDoc.createElement("div");
@@ -226,7 +247,7 @@ this.slideshowScript = (function() {
   }
 
   function hideSlideShow(event) {
-    if (event.target.className === "fv-close") {
+    if (event === null || event.target.className === "fv-close") {
       iframeContainer.style.display = "none";
       swapSlide();
     }
@@ -235,6 +256,7 @@ this.slideshowScript = (function() {
   function revealSlideshow() {
     swapSlide(slideElements[0]);
     iframeContainer.style.display = "block";
+    iframeContainer.focus();
   }
 
   function isVideoSourceUrl(url) {

--- a/extension/intents/slideshow/contentScript.js
+++ b/extension/intents/slideshow/contentScript.js
@@ -12,6 +12,21 @@ this.slideshowScript = (function() {
   const lbContainer = document.body.querySelector(".fv-lightbox-container");
   const slideContainer = document.body.querySelector(".fv-slide-image");
 
+  window.onresize = function() {
+    if (slideContainer.hasChildNodes()) {
+      if (slideContainer.firstChild.tagName === "IFRAME") {
+        slideContainer.firstChild.setAttribute(
+          "width",
+          document.documentElement.clientWidth
+        );
+        slideContainer.firstChild.setAttribute(
+          "height",
+          document.documentElement.clientHeight
+        );
+      }
+    }
+  };
+
   function buildSlideStructure() {
     const lightboxElement = document.createElement("div");
     lightboxElement.className = "fv-lightbox-container";
@@ -20,8 +35,13 @@ this.slideshowScript = (function() {
     const slideshowContainer = document.createElement("div");
     slideshowContainer.className = "fv-slideshow-container";
 
-    const slideImage = document.createElement("div");
-    slideImage.className = "fv-slide-image";
+    const navbar = document.createElement("div");
+    navbar.className = "fv-navbar";
+
+    const tagClose = document.createElement("a");
+    tagClose.className = "fv-close";
+    tagClose.textContent = String.fromCharCode(0x274c);
+    tagClose.onclick = hideSlideShow;
 
     const tagPrev = document.createElement("a");
     tagPrev.className = "fv-prev";
@@ -33,17 +53,25 @@ this.slideshowScript = (function() {
     tagNext.textContent = String.fromCharCode(10095);
     tagNext.onclick = nextSlide;
 
+    const slideImage = document.createElement("div");
+    slideImage.className = "fv-slide-image";
+
     slideshowContainer.appendChild(slideImage);
     slideshowContainer.appendChild(tagPrev);
     slideshowContainer.appendChild(tagNext);
 
+    navbar.appendChild(tagClose);
+    navbar.appendChild(tagNext);
+    navbar.appendChild(tagPrev);
+
+    lightboxElement.appendChild(navbar);
     lightboxElement.appendChild(slideshowContainer);
 
     document.body.appendChild(lightboxElement);
   }
 
   function hideSlideShow(event) {
-    if (event.target === lbContainer) {
+    if (event.target === document.body.querySelector(".fv-close")) {
       lbContainer.style.display = "none";
       swapSlide();
     }
@@ -95,8 +123,11 @@ this.slideshowScript = (function() {
           if (isVideoSourceUrl(element.getAttribute("src"))) {
             const iframe = document.createElement("iframe");
             iframe.setAttribute("src", element.getAttribute("src"));
-            iframe.setAttribute("width", 640);
-            iframe.setAttribute("height", 400);
+            iframe.setAttribute("width", document.documentElement.clientWidth);
+            iframe.setAttribute(
+              "height",
+              document.documentElement.clientHeight
+            );
             slideElements.push(iframe);
           }
 
@@ -138,6 +169,11 @@ this.slideshowScript = (function() {
       slideContainer.firstChild.remove();
     }
     if (newSlide) {
+      if (newSlide.tagName === "IFRAME") {
+        // enable iframe to resize first
+        newSlide.setAttribute("width", document.documentElement.clientWidth);
+        newSlide.setAttribute("height", document.documentElement.clientHeight);
+      }
       slideContainer.appendChild(newSlide);
     }
   }

--- a/extension/intents/slideshow/slideshow.html
+++ b/extension/intents/slideshow/slideshow.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+
+</head>
+<body>
+  
+</body>
+
+</html>

--- a/extension/intents/slideshow/slideshow.js
+++ b/extension/intents/slideshow/slideshow.js
@@ -1,0 +1,24 @@
+import * as intentRunner from "../../background/intentRunner.js";
+import * as content from "../../background/content.js";
+
+const SLIDESHOW_SCRIPT = "/intents/slideshow/contentScript.js";
+const SLIDESHOW_CSS = "/intents/slideshow/contentScript.css";
+
+intentRunner.registerIntent({
+    name: "slideshow.open",
+    async run(context) {
+        const activeTab = await context.activeTab();
+        const activeTabId = activeTab.id;
+        await content.lazyInject(activeTabId, SLIDESHOW_SCRIPT);
+        await browser.tabs.insertCSS(activeTabId, {file: SLIDESHOW_CSS});
+        const success = await browser.tabs.sendMessage(activeTabId, {
+            type: "openSlide"
+        });
+
+        if (!success) {
+            const err = new Error("Could not open slideshow");
+            err.displayMessage = "Could not open slideshow";
+            throw err;
+        }
+    }
+});

--- a/extension/intents/slideshow/slideshow.js
+++ b/extension/intents/slideshow/slideshow.js
@@ -5,20 +5,20 @@ const SLIDESHOW_SCRIPT = "/intents/slideshow/contentScript.js";
 const SLIDESHOW_CSS = "/intents/slideshow/contentScript.css";
 
 intentRunner.registerIntent({
-    name: "slideshow.open",
-    async run(context) {
-        const activeTab = await context.activeTab();
-        const activeTabId = activeTab.id;
-        await content.lazyInject(activeTabId, SLIDESHOW_SCRIPT);
-        await browser.tabs.insertCSS(activeTabId, {file: SLIDESHOW_CSS});
-        const success = await browser.tabs.sendMessage(activeTabId, {
-            type: "openSlide"
-        });
+  name: "slideshow.open",
+  async run(context) {
+    const activeTab = await context.activeTab();
+    const activeTabId = activeTab.id;
+    await content.lazyInject(activeTabId, SLIDESHOW_SCRIPT);
+    await browser.tabs.insertCSS(activeTabId, { file: SLIDESHOW_CSS });
+    const success = await browser.tabs.sendMessage(activeTabId, {
+      type: "openSlide",
+    });
 
-        if (!success) {
-            const err = new Error("Could not open slideshow");
-            err.displayMessage = "Could not open slideshow";
-            throw err;
-        }
+    if (!success) {
+      const err = new Error("Could not open slideshow");
+      err.displayMessage = "Could not open slideshow";
+      throw err;
     }
+  },
 });

--- a/extension/intents/slideshow/slideshow.js
+++ b/extension/intents/slideshow/slideshow.js
@@ -2,7 +2,6 @@ import * as intentRunner from "../../background/intentRunner.js";
 import * as content from "../../background/content.js";
 
 const SLIDESHOW_SCRIPT = "/intents/slideshow/contentScript.js";
-const SLIDESHOW_CSS = "/intents/slideshow/contentScript.css";
 
 intentRunner.registerIntent({
   name: "slideshow.open",
@@ -10,7 +9,7 @@ intentRunner.registerIntent({
     const activeTab = await context.activeTab();
     const activeTabId = activeTab.id;
     await content.lazyInject(activeTabId, SLIDESHOW_SCRIPT);
-    await browser.tabs.insertCSS(activeTabId, { file: SLIDESHOW_CSS });
+
     const success = await browser.tabs.sendMessage(activeTabId, {
       type: "openSlide",
     });

--- a/extension/intents/slideshow/slideshow.toml
+++ b/extension/intents/slideshow/slideshow.toml
@@ -1,0 +1,12 @@
+[slideshow.open]
+description = "Opens the slideshow"
+match = '''
+    (open | display | launch | start) (the |) (slideshow | slide shoe)
+'''
+
+[[slideshow.open.example]]
+phrase = "Open slideshow"
+
+[[slideshow.open.example]]
+phrase = "Launch the slideshow"
+test = true


### PR DESCRIPTION
Before submitting a final PR, please:

- [ ] Run `npm test` on your machine
- [x] Run `npm run format` to keep code formatted consistently
- [x] Reference the issue you are fixing in at least one of your commit messages, as `Fixes #X`

Fixes #1115
This is a first draft for the intent to start a slideshow of images and videos in a tab. Slideshow design is minimal, but may need more work. Tests are currently failing locally after a recent fork sync, particularly selenium tests I think. @ianb please kindly review.


