### PR TITLE
Set buildSettings.inDevelopment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             export VERSION="$(node bin/calculate-version.js)"
             export UPDATE_BASE="https://va.allizom.org/releases/dev"
             export INSTALL_CHANNEL=dev
-            export DEV_ICON=1
+            export IN_DEVELOPMENT=1
             mkdir -p artifacts/dev/
             npm run package
             mv addon.xpi artifacts/dev/firefox-voice.xpi

--- a/extension/background/main.js
+++ b/extension/background/main.js
@@ -103,11 +103,8 @@ export function inDevelopment() {
   return _inDevelopment || false;
 }
 
-let _extensionTemporaryInstall;
+let _extensionTemporaryInstall = buildSettings.inDevelopment;
 export function extensionTemporaryInstall() {
-  if (_extensionTemporaryInstall === undefined) {
-    throw new Error("Temporary installation status not yet established");
-  }
   return _extensionTemporaryInstall;
 }
 

--- a/extension/buildSettings.js.ejs
+++ b/extension/buildSettings.js.ejs
@@ -1,6 +1,6 @@
 this.buildSettings = {
   logLevel: <%= env.LOG_LEVEL || "debug" %>,
-  inDevelopment: null,
+  inDevelopment: <%= !!env.IN_DEVELOPMENT %>,
   sttServer: "https://speaktome-2.services.mozilla.com",
   deepSpeechServer: "https://dev.speaktome.nonprod.cloudops.mozgcp.net",
   sendToDeepSpeech: true,

--- a/extension/manifest.json.ejs
+++ b/extension/manifest.json.ejs
@@ -87,7 +87,7 @@
     "browser_style": false,
     "default_title": "Firefox Voice",
     "default_icon":
-      <% if (env.DEV_ICON) { %>
+      <% if (env.IN_DEVELOPMENT) { %>
         "popup/images/mic-dev.svg",
       <% } else { %>
         "popup/images/mic.svg",

--- a/package.json
+++ b/package.json
@@ -80,10 +80,10 @@
   },
   "scripts": {
     "start": "concurrently --kill-others --success first --names watch,browser 'npm run watch' 'npm run start-and-build'",
-    "start-and-build": "NO_SENTRY=1 DEV_ICON=1 npm-run-all maybeinstall build:templates build:manifest build:intent-metadata start-extension",
+    "start-and-build": "NO_SENTRY=1 IN_DEVELOPMENT=1 npm-run-all maybeinstall build:templates build:manifest build:intent-metadata start-extension",
     "start-extension": "mkdir -p ${PROFILE:-Profile} && web-ext run --firefox-profile ${PROFILE:-Profile}/ --keep-profile-changes --firefox \"${FIREFOX:-nightly}\" --source-dir extension/ --browser-console --pref=extensions.experiments.enabled=true",
     "start-android": "concurrently --kill-others --success first --names watch,android 'npm run watch' 'npm run start-and-build-android'",
-    "start-and-build-android": "NO_SENTRY=1 DEV_ICON=1 ANDROID=1 npm-run-all maybeinstall build:templates build:manifest build:intent-metadata start-android-extension",
+    "start-and-build-android": "NO_SENTRY=1 IN_DEVELOPMENT=1 ANDROID=1 npm-run-all maybeinstall build:templates build:manifest build:intent-metadata start-android-extension",
     "start-android-extension": "web-ext run --target=firefox-android --source-dir extension/ --android-device ${ANDROID_DEVICE:-please_set_ANDROID_DEVICE} --firefox-apk ${FIREFOX_APK:-org.mozilla.firefox}",
     "test": "npm-run-all build:manifest build:intent-metadata lint jest",
     "test-ci": "npm-run-all build:manifest build:intent-metadata lint",


### PR DESCRIPTION
We were overthinking this setting using temporaryInstall, when we could simply set inDevelopment in the build process.
