### PR TITLE
Always opens a new tab on search intent

### DIFF
--- a/extension/intents/search/search.js
+++ b/extension/intents/search/search.js
@@ -6,12 +6,15 @@ import * as content from "../../background/content.js";
 import * as telemetry from "../../background/telemetry.js";
 import * as browserUtil from "../../browserUtil.js";
 
+// Close the search tab after this amount of time:
+const CLOSE_TIME = 1000 * 60 * 60; // 1 hour
 // Hide the search tab after this amount of unfocused time:
 const HIDE_TIME = 1000 * 60; // 1 minute
 // Check this often for a new image in a search tab:
 const CARD_POLL_INTERVAL = 200; // milliseconds
 // If we don't believe the card is animated, still get new images for this amount of time:
 const CARD_POLL_LIMIT = 1000; // milliseconds
+let closeTabTimeout = null;
 let lastImage = null;
 let _searchTabId;
 const START_URL = "https://www.google.com/?voice";
@@ -24,8 +27,23 @@ const tabSearchResults = new browserUtil.TabDataMap(5 * 60 * 1000); // only dele
 let googleIsDefaultProvider;
 
 async function openSearchTab() {
-  _searchTabId = null;
-
+  if (closeTabTimeout) {
+    clearTimeout(closeTabTimeout);
+    closeTabTimeout = null;
+  }
+  closeTabTimeout = setTimeout(() => {
+    closeSearchTab();
+  }, CLOSE_TIME);
+  if (_searchTabId) {
+    try {
+      await browser.tabs.get(_searchTabId);
+      return _searchTabId;
+    } catch (e) {
+      // Presumably the tab doesn't exist
+      log.info("Error getting tab:", String(e));
+      _searchTabId = null;
+    }
+  }
   for (const tab of await browser.tabs.query({
     url: ["https://www.google.com/*"],
   })) {
@@ -45,6 +63,18 @@ async function openSearchTab() {
   return _searchTabId;
 }
 
+async function closeSearchTab() {
+  if (!_searchTabId) {
+    return;
+  }
+  const tabId = _searchTabId;
+  await browser.tabs.remove(tabId);
+  browser.tabs.onActivated.removeListener(_tabHideListener);
+  // Technically there is a race condition here, but without some lock this is just going to be racy,
+  // so this race is better than the other one
+  // eslint-disable-next-line require-atomic-updates
+  _searchTabId = null;
+}
 
 async function focusSearchTab() {
   await browser.tabs.show(_searchTabId);
@@ -363,7 +393,12 @@ intentRunner.registerIntent({
     if (buildSettings.android) {
       await performSearch(context.slots.query);
     } else {
-      const tabId = await openSearchTab();
+      const tab = await browser.tabs.create({
+        url: START_URL,
+        active: false,
+      });
+      const tabId = tab.id ;
+      _searchTabId = tabId ;
 
       await browser.search.search({
         query: context.slots.query,


### PR DESCRIPTION
# fixes #1246 

refactors openSearchTab() to always open new tab on search intent
removes closeSearchTab()

Before submitting a final PR, please:

- [x] Run `npm test` on your machine
- [x] Run `npm run format` to keep code formatted consistently
- [x] Reference the issue you are fixing in at least one of your commit messages, as `Fixes #X`

I have refactored `openSearchTab()` to always open a new tab on search intent. 