### PR TITLE
Fixes #1194 - "Google for X"

### DIFF
--- a/extension/intents/search/search.js
+++ b/extension/intents/search/search.js
@@ -410,6 +410,20 @@ intentRunner.registerIntent({
   },
 });
 
+intentRunner.registerIntent({
+  name: "search.searchGoogle",
+  async run(context) {
+    if (buildSettings.android) {
+      await performSearch(context.slots.query);
+    } else {
+      await browser.search.search({
+        query: context.slots.query,
+        engine: "Google"
+      });
+    }
+  },
+}); 
+
 async function init() {
   const engines = await browser.search.get();
   for (const engine of engines) {

--- a/extension/intents/search/search.js
+++ b/extension/intents/search/search.js
@@ -418,11 +418,11 @@ intentRunner.registerIntent({
     } else {
       await browser.search.search({
         query: context.slots.query,
-        engine: "Google"
+        engine: "Google",
       });
     }
   },
-}); 
+});
 
 async function init() {
   const engines = await browser.search.get();

--- a/extension/intents/search/search.toml
+++ b/extension/intents/search/search.toml
@@ -130,7 +130,7 @@ test = true
 [search.searchGoogle]
 description = "Give search results from google"
 match = """
-  (google) (for |) [query]
+  (search | query | find | look up | lookup | look on |) (google) (for |) [query] (for me |)
 """
 
 [[search.searchGoogle.example]]

--- a/extension/intents/search/search.toml
+++ b/extension/intents/search/search.toml
@@ -130,10 +130,14 @@ test = true
 [search.searchGoogle]
 description = "Give search results from google"
 match = """
-  (search | query | find | look up | lookup | look on |) (google) (for |) [query] (for me |)
+  (do a |) (search | search on | query | find | look up | lookup | look on |) (google) (for | for the |) [query] (for me |)
+  (do a |) (search | query | find | look up | lookup | look on | look for |) (for | for the |) [query] (on |) (google) (for me |)
 """
 
 [[search.searchGoogle.example]]
-phrase = "google query"
-test = true
+phrase = "google waterfall"
+expectSlots = {query = "query"}
+
+[[search.searchGoogle.example]]
+phrase = "search for fox news on google"
 expectSlots = {query = "query"}

--- a/extension/intents/search/search.toml
+++ b/extension/intents/search/search.toml
@@ -41,7 +41,7 @@ test = true
 [search.search]
 description = "Experimental search interface; this does all searches in a special pinned tab, and if the search results in a card then a screenshot of the card is displayed in the popup. If there's no card, then the first search result is opened in a new tab."
 match = """
-  (do a |) (query | find | find me | look up | lookup | look on | look for) (google | the web | the internet |) (for |) [query] (on the web |) (for me |)
+  (do a |) (query | find | find me | look up | lookup | look on | look for) (the web | the internet |) (for |) [query] (on the web |) (for me |)
 """
 
 [[search.search.example]]
@@ -77,7 +77,7 @@ phrase = "How do I get to the hardware store?"
 [search.searchPage]
 description = "Opens a search page"
 match = """
-  (do a |) (search | google | look on) (google | the web | the internet |) (for |) [query] (on the web |) (for me|)
+  (do a |) (search | look on) (the web | the internet |) (for |) [query] (on the web |) (for me|)
 """
 
 [[search.searchPage.example]]
@@ -88,11 +88,6 @@ phrase = "search for tops"
 
 [[search.searchPage.example]]
 phrase = "do a search for query on the web for me"
-test = true
-expectSlots = {query = "query"}
-
-[[search.searchPage.example]]
-phrase = "google query"
 test = true
 expectSlots = {query = "query"}
 
@@ -131,3 +126,14 @@ match = """
 [[search.defaultSearchEngine.example]]
 phrase = "search"
 test = true
+
+[search.searchGoogle]
+description = "Give search results from google"
+match = """
+  (google) (for |) [query]
+"""
+
+[[search.searchGoogle.example]]
+phrase = "google query"
+test = true
+expectSlots = {query = "query"}


### PR DESCRIPTION
Fix for: **#1194** google for X" should always open Google.

- Removes google matches and examples from `search.seacrh` and `search.searchPage` intents, to separate out google search - search.toml.

- Adds new intent named `search.searchGoogle` - search.toml

- Registers the `search.searchGoogle`intent - search.js

`Fixes #1194`
