### PR TITLE
Fixes Copy Rich Link for Google Services

### DIFF
--- a/extension/intents/clipboard/contentScript.js
+++ b/extension/intents/clipboard/contentScript.js
@@ -91,9 +91,13 @@ this.contentScript = (function() {
   types.copyRichLink = function() {
     const m = meta();
     const anchor = document.createElement("a");
+    if (window.location.href.includes("google")) {
+      return (m.title + " : " + m.canonical );
+    }
     anchor.href = m.canonical;
     anchor.textContent = m.title;
     copyElement(anchor);
+    return false;
   };
 
   types.copyScreenshot = function() {


### PR DESCRIPTION
# Fixes #1205 

Before submitting a final PR, please:

- [x] Run `npm test` on your machine
- [x] Run `npm run format` to keep code formatted consistently
- [x] Reference the issue you are fixing in at least one of your commit messages, as `Fixes #X`

This PR fixes the issues with copying Rich Link in Google Services and enables copying of rich link from Google Services.


