### PR TITLE
Hides wakeword settings from production build

### DIFF
--- a/extension/background/main.js
+++ b/extension/background/main.js
@@ -128,6 +128,8 @@ const temporaryInstallId = setTimeout(() => {
   if (_extensionTemporaryInstall === undefined) {
     _extensionTemporaryInstall = false;
   }
+
+  _inDevelopment = buildSettings.inDevelopment;
 }, 5000);
 
 browser.runtime.onInstalled.addListener(details => {

--- a/extension/options/optionsView.jsx
+++ b/extension/options/optionsView.jsx
@@ -118,12 +118,12 @@ const General = ({
         keyboardShortcutError={keyboardShortcutError}
       />
       {buildSettings.inDevelopment ? (
-      <WakewordSettings
-        userOptions={userOptions}
-        userSettings={userSettings}
-        updateUserSettings={updateUserSettings}
-      />
-      ): null}
+        <WakewordSettings
+          userOptions={userOptions}
+          userSettings={userSettings}
+          updateUserSettings={updateUserSettings}
+        />
+      ) : null}
       <MusicServiceSettings
         userOptions={userOptions}
         userSettings={userSettings}

--- a/extension/options/optionsView.jsx
+++ b/extension/options/optionsView.jsx
@@ -117,7 +117,7 @@ const General = ({
         updateUserSettings={updateUserSettings}
         keyboardShortcutError={keyboardShortcutError}
       />
-      {buildSettings.inDevelopment ? (
+      {inDevelopment ? (
         <WakewordSettings
           userOptions={userOptions}
           userSettings={userSettings}

--- a/extension/options/optionsView.jsx
+++ b/extension/options/optionsView.jsx
@@ -117,11 +117,13 @@ const General = ({
         updateUserSettings={updateUserSettings}
         keyboardShortcutError={keyboardShortcutError}
       />
+      {buildSettings.inDevelopment ? (
       <WakewordSettings
         userOptions={userOptions}
         userSettings={userSettings}
         updateUserSettings={updateUserSettings}
       />
+      ): null}
       <MusicServiceSettings
         userOptions={userOptions}
         userSettings={userSettings}


### PR DESCRIPTION
Fixes #1344 

- setting _inDevelopment in (temporaryInstallId function) for cases where onInstalled do not get fired

Before submitting a final PR, please:

- [x] Run `npm test` on your machine
- [x] Run `npm run format` to keep code formatted consistently
- [x] Reference the issue you are fixing in at least one of your commit messages, as `Fixes #X`
