### PR TITLE
Reuse youtube tabs

### DIFF
--- a/extension/background/intentRunner.js
+++ b/extension/background/intentRunner.js
@@ -153,8 +153,10 @@ export class IntentContext {
 
   async createTabGoogleLucky(query, options = {}) {
     const searchUrl = searching.googleSearchUrl(query, true);
-    const tab = !!options.youtubeTabId && options.youtubeTabId > -1? 
-    await browserUtil.loadUrl(options.youtubeTabId,searchUrl) : await this.createTab({ url: searchUrl });
+    const tab =
+      !!options.youtubeTabId && options.youtubeTabId > -1
+        ? await browserUtil.loadUrl(options.youtubeTabId, searchUrl)
+        : await this.createTab({ url: searchUrl });
     if (options.hide && !buildSettings.android) {
       await browser.tabs.hide(tab.id);
     }

--- a/extension/background/intentRunner.js
+++ b/extension/background/intentRunner.js
@@ -153,7 +153,8 @@ export class IntentContext {
 
   async createTabGoogleLucky(query, options = {}) {
     const searchUrl = searching.googleSearchUrl(query, true);
-    const tab = await this.createTab({ url: searchUrl });
+    const tab = !!options.youtubeTabId && options.youtubeTabId > -1? 
+    await browserUtil.loadUrl(options.youtubeTabId,searchUrl) : await this.createTab({ url: searchUrl });
     if (options.hide && !buildSettings.android) {
       await browser.tabs.hide(tab.id);
     }

--- a/extension/background/intentRunner.js
+++ b/extension/background/intentRunner.js
@@ -154,8 +154,8 @@ export class IntentContext {
   async createTabGoogleLucky(query, options = {}) {
     const searchUrl = searching.googleSearchUrl(query, true);
     const tab =
-      !!options.youtubeTabId && options.youtubeTabId > -1
-        ? await browserUtil.loadUrl(options.youtubeTabId, searchUrl)
+      !!options.openInTabId && options.openInTabId > -1
+        ? await browserUtil.loadUrl(options.openInTabId, searchUrl)
         : await this.createTab({ url: searchUrl });
     if (options.hide && !buildSettings.android) {
       await browser.tabs.hide(tab.id);

--- a/extension/services/youtube/youtube.js
+++ b/extension/services/youtube/youtube.js
@@ -24,15 +24,18 @@ async function waitForUrl(tabId, options) {
 
 class YouTube extends serviceList.Service {
   async getYoutubeTabId() {
-    const youtubeTabs = await this.getAllTabs({ currentWindow: true });
-    return !!youtubeTabs && youtubeTabs[0] && youtubeTabs[0].id
+    const youtubeTabs = await this.getAllTabs({
+      currentWindow: true,
+      active: true,
+    });
+    return !!youtubeTabs && !!youtubeTabs[0] && !!youtubeTabs[0].id
       ? youtubeTabs[0].id
       : -1;
   }
   async playQuery(query) {
     const tabId = await this.getYoutubeTabId();
     this.tab = await this.context.createTabGoogleLucky(`${query} youtube.com`, {
-      youtubeTabId: tabId,
+      openInTabId: tabId,
     });
     this.tabCreated = true;
     // We only test for audibility if the URL seems correct

--- a/extension/services/youtube/youtube.js
+++ b/extension/services/youtube/youtube.js
@@ -23,14 +23,17 @@ async function waitForUrl(tabId, options) {
 }
 
 class YouTube extends serviceList.Service {
-
-  async getYoutubeTabId(){
-    const youtubeTabs = await this.getAllTabs({currentWindow:true})
-    return !!youtubeTabs && youtubeTabs[0] && youtubeTabs[0].id ? youtubeTabs[0].id : -1
+  async getYoutubeTabId() {
+    const youtubeTabs = await this.getAllTabs({ currentWindow: true });
+    return !!youtubeTabs && youtubeTabs[0] && youtubeTabs[0].id
+      ? youtubeTabs[0].id
+      : -1;
   }
   async playQuery(query) {
-    const tabId = await this.getYoutubeTabId()
-    this.tab = await this.context.createTabGoogleLucky(`${query} youtube.com`,{youtubeTabId: tabId});
+    const tabId = await this.getYoutubeTabId();
+    this.tab = await this.context.createTabGoogleLucky(`${query} youtube.com`, {
+      youtubeTabId: tabId,
+    });
     this.tabCreated = true;
     // We only test for audibility if the URL seems correct
     const loadedTab = await waitForUrl(this.tab.id, {

--- a/extension/services/youtube/youtube.js
+++ b/extension/services/youtube/youtube.js
@@ -23,8 +23,14 @@ async function waitForUrl(tabId, options) {
 }
 
 class YouTube extends serviceList.Service {
+
+  async getYoutubeTabId(){
+    const youtubeTabs = await this.getAllTabs({currentWindow:true})
+    return !!youtubeTabs && youtubeTabs[0] && youtubeTabs[0].id ? youtubeTabs[0].id : -1
+  }
   async playQuery(query) {
-    this.tab = await this.context.createTabGoogleLucky(`${query} youtube.com`);
+    const tabId = await this.getYoutubeTabId()
+    this.tab = await this.context.createTabGoogleLucky(`${query} youtube.com`,{youtubeTabId: tabId});
     this.tabCreated = true;
     // We only test for audibility if the URL seems correct
     const loadedTab = await waitForUrl(this.tab.id, {


### PR DESCRIPTION
This solves the following issue:
1. When a youtube tab is open and one says "play song name" the existing tab is used
Fixes #397 