### PR TITLE
Adjust Music Service Volume

### DIFF
--- a/extension/background/musicService.js
+++ b/extension/background/musicService.js
@@ -76,6 +76,21 @@ class MusicService extends serviceList.Service {
       await this.callOneTab(tab.id, "pause");
     }
   }
+
+  async adjustVolume(volumeLevel) {
+    await this.initTab(`/services/${this.id}/player.js`);
+    await this.callTab("adjustVolume", { volumeLevel });
+  }
+
+  async mute() {
+    await this.initTab(`/services/${this.id}/player.js`);
+    await this.callTab("mute");
+  }
+
+  async unmute() {
+    await this.initTab(`/services/${this.id}/player.js`);
+    await this.callTab("unmute");
+  }
 }
 
 export default MusicService;

--- a/extension/intents/music/music.js
+++ b/extension/intents/music/music.js
@@ -139,7 +139,7 @@ intentRunner.registerIntent({
   name: "music.volume",
   async run(context) {
     const service = await getService(context, { lookAtCurrentTab: true });
-    await service.adjustVolume(context.parameters.level);
+    await service.adjustVolume(context.parameters.volumeLevel);
   },
 });
 intentRunner.registerIntent({

--- a/extension/intents/music/music.js
+++ b/extension/intents/music/music.js
@@ -135,5 +135,28 @@ intentRunner.registerIntent({
   },
 });
 
+intentRunner.registerIntent({
+  name: "music.volume",
+  async run(context) {
+    const service = await getService(context, { lookAtCurrentTab: true });
+    await service.adjustVolume(context.parameters.level);
+  },
+});
+intentRunner.registerIntent({
+  name: "music.mute",
+  async run(context) {
+    const service = await getService(context, { lookAtCurrentTab: true });
+    await service.mute();
+  },
+});
+
+intentRunner.registerIntent({
+  name: "music.unmute",
+  async run(context) {
+    const service = await getService(context, { lookAtCurrentTab: true });
+    await service.unmute();
+  },
+});
+
 // FIXME: workaround for a legacy module needing access to this function:
 window.music_getServiceNamesAndTitles = getServiceNamesAndTitles;

--- a/extension/intents/music/music.toml
+++ b/extension/intents/music/music.toml
@@ -160,15 +160,15 @@ test = true
 [music.volume]
 description = "Adjust music volume"
 match = """
-  (increase | turn up) (music | audio | video |) (volume | the volume) [level=levelUp] 
-  (make it louder | louder) [level=levelUp] 
-  (decrease | turn down) (music | audio | video |) (volume | the volume) [level=levelDown] 
-  (make it softer | softer) [level=levelDown] 
+  (increase | turn up) (music | audio | video |) (volume | the volume) [volumeLevel=levelUp] 
+  (make it louder | louder) [volumeLevel=levelUp] 
+  (decrease | turn down) (music | audio | video |) (volume | the volume) [volumeLevel=levelDown] 
+  (make it softer | softer) [volumeLevel=levelDown] 
 """
 
 [music.volume.example]
 phrase = "increase volume"
-expectParameters = {level = "levelUp"}
+expectParameters = {volumeLevel = "levelUp"}
 
 [music.mute]
 description = "mute music volume"

--- a/extension/intents/music/music.toml
+++ b/extension/intents/music/music.toml
@@ -156,3 +156,36 @@ phrase = "What is playing"
 [[music.showTitle.example]]
 phrase = "What's playing?"
 test = true
+
+[music.volume]
+description = "Adjust music volume"
+match = """
+  (increase | turn up) (music | audio | video |) (volume | the volume) [level=levelUp] 
+  (make it louder | louder) [level=levelUp] 
+  (decrease | turn down) (music | audio | video |) (volume | the volume) [level=levelDown] 
+  (make it softer | softer) [level=levelDown] 
+"""
+
+[music.volume.example]
+phrase = "increase volume"
+expectParameters = {level = "levelUp"}
+
+[music.mute]
+description = "mute music volume"
+match = """
+  mute (music | audio | video) (volume |)
+  mute (volume | the volume)
+"""
+
+[music.mute.example]
+phrase = "mute music"
+
+[music.unmute]
+description = "unmute music volume"
+match = """
+  unmute (music | audio | video) (volume |)
+  unmute (volume | the volume) 
+"""
+
+[music.unmute.example]
+phrase = "unmute video"

--- a/extension/intents/muting/muting.toml
+++ b/extension/intents/muting/muting.toml
@@ -1,22 +1,22 @@
 [muting.mute]
 description = "Mute all audible tabs (new tabs or silent tabs are not muted); does not pause any media, only mute the sound"
 match = """
-  (mute | turn off) (whatever is |) (playing | all |) (the |) (music | audio | sound | everything | tab{s}) (for me |)
+  (mute | turn off) (whatever is |) (playing | all |) (the |) (sound | everything | tab{s} |) (for me |)
   mute
-  quiet (tabs{s} |) (for me |)
+  (be |) quiet (tabs{s} |) (for me |)
   shut up (tab{s} |) (for me |)
+  silence
 """
 
 [[muting.mute.example]]
 phrase = "mute (all tabs)"
-
 
 [[muting.mute.example]]
 phrase = "shut up tabs for me"
 test = true
 
 [[muting.mute.example]]
-phrase = "mute playing audio"
+phrase = "mute playing sound"
 test = true
 
 [[muting.mute.example]]
@@ -26,7 +26,7 @@ test = true
 [muting.muteTab]
 description = "Mute just the active page"
 match = """
-  (mute | quiet | shot up) (this |) (page | tab)
+  (mute | quiet | shut up) (this |) (page | tab)
 """
 
 [[muting.muteTab.example]]

--- a/extension/services/deezer/deezer.js
+++ b/extension/services/deezer/deezer.js
@@ -6,7 +6,7 @@ class Deezer extends MusicService {}
 Object.assign(Deezer, {
   id: "deezer",
   title: "Deezer",
-  baseUrl: "https://deezer.com/",
+  baseUrl: "https://www.deezer.com/",
 });
 
 music.register(Deezer);

--- a/extension/services/deezer/player.js
+++ b/extension/services/deezer/player.js
@@ -50,6 +50,80 @@ this.player = (function() {
         button.click();
       }
     }
+
+    getVolumeSliderTracker() {
+      const svgIconGroupBtn = this.querySelectorAll(".svg-icon-group-btn");
+      const volumeBtn = svgIconGroupBtn[svgIconGroupBtn.length - 2];
+      const mouseover = new MouseEvent("mouseover", {
+        view: window,
+        bubbles: true,
+        cancelable: true,
+      });
+      volumeBtn.dispatchEvent(mouseover);
+      const slidersTrackInput = this.querySelectorAll(".slider-track-input");
+      return slidersTrackInput;
+    }
+
+    isMuted() {
+      const slidersTrackInput = this.getVolumeSliderTracker();
+      const volumeNow = parseInt(
+        slidersTrackInput[1].getAttribute("aria-valuenow")
+      );
+      const muted = volumeNow ? 0 : 1;
+      return muted;
+    }
+
+    action_adjustVolume({ volumeLevel }) {
+      const maxVolume = 100;
+      const minVolume = 0;
+      const volumeChange = 20;
+      const volumeChangeSteps = volumeChange;
+      const slidersTrackInput = this.getVolumeSliderTracker();
+      const volumeNow = parseInt(
+        slidersTrackInput[1].getAttribute("aria-valuenow")
+      );
+
+      if (volumeLevel === "levelUp" && volumeNow < maxVolume) {
+        if (this.isMuted()) {
+          this.action_unmute();
+        }
+        const volumeup = new KeyboardEvent("keypress", {
+          bubbles: true,
+          key: "ArrowUp",
+          keyCode: 38,
+          shiftKey: true,
+        });
+        for (let step = 0; step < volumeChangeSteps; step++) {
+          slidersTrackInput[1].dispatchEvent(volumeup);
+        }
+      } else if (volumeLevel === "levelDown" && volumeNow > minVolume) {
+        const volumedown = new KeyboardEvent("keypress", {
+          bubbles: true,
+          key: "ArrowDown",
+          keyCode: 40,
+          shiftKey: true,
+        });
+        for (let step = 0; step < volumeChangeSteps; step++) {
+          slidersTrackInput[1].dispatchEvent(volumedown);
+        }
+      }
+    }
+
+    action_mute() {
+      if (!this.isMuted()) {
+        const iconVolume = this.querySelector(".svg-icon-volume");
+        const iconVolumeParent = iconVolume.closest(".svg-icon-group-btn");
+        iconVolumeParent.click();
+      }
+    }
+
+    action_unmute() {
+      if (this.isMuted()) {
+        const iconVolumeOff = this.querySelector(".svg-icon-volume-off");
+        const iconVolumeParent = iconVolumeOff.closest(".svg-icon-group-btn");
+        iconVolumeParent.click();
+      }
+    }
   }
 
   Player.register();

--- a/extension/services/soundcloud/player.js
+++ b/extension/services/soundcloud/player.js
@@ -57,9 +57,8 @@ this.player = (function() {
         }
         const volumeup = new KeyboardEvent("keydown", {
           bubbles: true,
-          key: 38,
+          key: "ArrowUp",
           keyCode: 38,
-          which: 38,
           shiftKey: true,
         });
         for (let step = 0; step < volumeChangeSteps; step++) {
@@ -68,9 +67,8 @@ this.player = (function() {
       } else if (volumeLevel === "levelDown" && volumeNow > minVolume) {
         const volumedown = new KeyboardEvent("keydown", {
           bubbles: true,
-          key: 40,
+          key: "ArrowDown",
           keyCode: 40,
-          which: 40,
           shiftKey: true,
         });
         for (let step = 0; step < volumeChangeSteps; step++) {

--- a/extension/services/soundcloud/player.js
+++ b/extension/services/soundcloud/player.js
@@ -47,34 +47,34 @@ this.player = (function() {
       const minVolume = 0.0;
       const volumeChangeReceiver = this.querySelector(".volume");
       const sliderWrapper = this.querySelector(".volume__sliderWrapper");
-      let volumeNow = parseFloat(sliderWrapper.getAttribute("aria-valuenow"));
-      let volumeChange = 0.2;
-      let volumeChangeSteps = volumeChange * 10;
-      
+      const volumeNow = parseFloat(sliderWrapper.getAttribute("aria-valuenow"));
+      const volumeChange = 0.2;
+      const volumeChangeSteps = volumeChange * 10;
+
       if (volumeLevel === "levelUp" && volumeNow < maxVolume) {
         if (this.isMuted()) {
           this.action_unmute();
         }
-        var keydownEvent = new KeyboardEvent("keydown", {
+        const volumeup = new KeyboardEvent("keydown", {
           bubbles: true,
           key: 38,
           keyCode: 38,
           which: 38,
-          shiftKey: true, 
-        });  
+          shiftKey: true,
+        });
         for (let step = 0; step < volumeChangeSteps; step++) {
-          volumeChangeReceiver.dispatchEvent(keydownEvent);
+          volumeChangeReceiver.dispatchEvent(volumeup);
         }
       } else if (volumeLevel === "levelDown" && volumeNow > minVolume) {
-        var keydownEvent = new KeyboardEvent("keydown", {
+        const volumedown = new KeyboardEvent("keydown", {
           bubbles: true,
           key: 40,
           keyCode: 40,
           which: 40,
-          shiftKey: true, 
-        });  
+          shiftKey: true,
+        });
         for (let step = 0; step < volumeChangeSteps; step++) {
-          volumeChangeReceiver.dispatchEvent(keydownEvent);
+          volumeChangeReceiver.dispatchEvent(volumedown);
         }
       }
     }
@@ -82,7 +82,7 @@ this.player = (function() {
     isMuted() {
       const sliderWrapper = this.querySelector(".volume__sliderWrapper");
       const volumeNow = parseFloat(sliderWrapper.getAttribute("aria-valuenow"));
-      const muted =  volumeNow === 0;
+      const muted = volumeNow === 0;
       return muted ? 1 : 0;
     }
 

--- a/extension/services/soundcloud/player.js
+++ b/extension/services/soundcloud/player.js
@@ -41,6 +41,64 @@ this.player = (function() {
         playControlsBtn[0].click();
       }
     }
+
+    action_adjustVolume({ volumeLevel }) {
+      const maxVolume = 1.0;
+      const minVolume = 0.0;
+      const volumeChangeReceiver = this.querySelector(".volume");
+      const sliderWrapper = this.querySelector(".volume__sliderWrapper");
+      let volumeNow = parseFloat(sliderWrapper.getAttribute("aria-valuenow"));
+      let volumeChange = 0.2;
+      let volumeChangeSteps = volumeChange * 10;
+      
+      if (volumeLevel === "levelUp" && volumeNow < maxVolume) {
+        if (this.isMuted()) {
+          this.action_unmute();
+        }
+        var keydownEvent = new KeyboardEvent("keydown", {
+          bubbles: true,
+          key: 38,
+          keyCode: 38,
+          which: 38,
+          shiftKey: true, 
+        });  
+        for (let step = 0; step < volumeChangeSteps; step++) {
+          volumeChangeReceiver.dispatchEvent(keydownEvent);
+        }
+      } else if (volumeLevel === "levelDown" && volumeNow > minVolume) {
+        var keydownEvent = new KeyboardEvent("keydown", {
+          bubbles: true,
+          key: 40,
+          keyCode: 40,
+          which: 40,
+          shiftKey: true, 
+        });  
+        for (let step = 0; step < volumeChangeSteps; step++) {
+          volumeChangeReceiver.dispatchEvent(keydownEvent);
+        }
+      }
+    }
+
+    isMuted() {
+      const sliderWrapper = this.querySelector(".volume__sliderWrapper");
+      const volumeNow = parseFloat(sliderWrapper.getAttribute("aria-valuenow"));
+      const muted =  volumeNow === 0;
+      return muted ? 1 : 0;
+    }
+
+    action_mute() {
+      if (!this.isMuted()) {
+        const muteButton = this.querySelector(".volume__button");
+        muteButton.click();
+      }
+    }
+
+    action_unmute() {
+      if (this.isMuted()) {
+        const unmuteButton = this.querySelector(".volume__button");
+        unmuteButton.click();
+      }
+    }
   }
   Player.register();
 })();

--- a/extension/services/youtube/player.js
+++ b/extension/services/youtube/player.js
@@ -60,6 +60,64 @@ this.player = (function() {
       const button = this.querySelector(`${this.selector} .ytp-next-button`);
       button.click();
     }
+
+    action_adjustVolume({level}) {
+      const maxVolume = 1.0;
+      const minVolume = 0.0;
+      const ytVideo = this.querySelector(`${this.selector} .html5-main-video`);
+      const volumePanel = this.querySelector(`${this.selector} .ytp-volume-panel`);
+      const volumeSliderHandle = this.querySelector(`${this.selector} .ytp-volume-slider-handle`);
+      let vol = ytVideo.volume;
+      let ariaValueNow = parseInt(volumePanel.getAttribute('aria-valuenow'));
+      let volumeSliderValue = ariaValueNow / 2.5;
+
+      if(level === "levelUp" && vol < 1.0) {
+        vol = (vol <= maxVolume - 0.2) ? (vol + 0.2) : maxVolume; 
+        ytVideo.volume = vol;
+        ariaValueNow = Math.round(vol / 0.01);
+        volumeSliderValue = ariaValueNow / 2.5;
+
+        ytVideo.onvolumechange = () => {
+          volumePanel.setAttribute("aria-valuenow", ariaValueNow); 
+          volumePanel.setAttribute("aria-valuetext", `${ariaValueNow}% volume`);
+          volumeSliderHandle.style.left = `${volumeSliderValue}px`; 
+        };
+      }
+      else if(level === "levelDown" && vol > 0.0) {
+        vol = (vol >= minVolume + 0.2) ? (vol - 0.2) : minVolume; 
+        ytVideo.volume = vol;
+        ariaValueNow = Math.round(vol / 0.01);
+        volumeSliderValue = ariaValueNow / 2.5;
+
+        ytVideo.onvolumechange = () => {
+          volumePanel.setAttribute("aria-valuenow", ariaValueNow); 
+          volumePanel.setAttribute("aria-valuetext", `${ariaValueNow}% volume`);
+          volumeSliderHandle.style.left = `${volumeSliderValue}px`; 
+        };
+      }
+    }
+
+    getVolume() {
+      let volumePanel = document.querySelector('.ytp-volume-panel');
+      let vol = parseInt(volumePanel.getAttribute('aria-valuenow'));
+      let isMuted = volumePanel.getAttribute('aria-valuetext').match(/muted/) != null;
+    
+      return isMuted ? 0 : vol;
+    }
+
+    action_mute(){
+      if(this.getVolume()) {
+        const muteButton = this.querySelector(`${this.selector} .ytp-mute-button[aria-label^='Mute']`);
+        muteButton.click();
+      }  
+    }
+
+    action_unmute(){
+      if(! this.getVolume()) {
+        const unmuteButton = this.querySelector(`${this.selector} .ytp-mute-button[aria-label^='Unmute']`);
+        unmuteButton.click();
+      }
+    }
   }
 
   Player.register();

--- a/extension/services/youtube/player.js
+++ b/extension/services/youtube/player.js
@@ -61,60 +61,68 @@ this.player = (function() {
       button.click();
     }
 
-    action_adjustVolume({level}) {
+    action_adjustVolume({ level }) {
       const maxVolume = 1.0;
       const minVolume = 0.0;
       const ytVideo = this.querySelector(`${this.selector} .html5-main-video`);
-      const volumePanel = this.querySelector(`${this.selector} .ytp-volume-panel`);
-      const volumeSliderHandle = this.querySelector(`${this.selector} .ytp-volume-slider-handle`);
+      const volumePanel = this.querySelector(
+        `${this.selector} .ytp-volume-panel`
+      );
+      const volumeSliderHandle = this.querySelector(
+        `${this.selector} .ytp-volume-slider-handle`
+      );
       let vol = ytVideo.volume;
-      let ariaValueNow = parseInt(volumePanel.getAttribute('aria-valuenow'));
+      let ariaValueNow = parseInt(volumePanel.getAttribute("aria-valuenow"));
       let volumeSliderValue = ariaValueNow / 2.5;
 
-      if(level === "levelUp" && vol < 1.0) {
-        vol = (vol <= maxVolume - 0.2) ? (vol + 0.2) : maxVolume; 
+      if (level === "levelUp" && vol < 1.0) {
+        vol = vol <= maxVolume - 0.2 ? vol + 0.2 : maxVolume;
         ytVideo.volume = vol;
         ariaValueNow = Math.round(vol / 0.01);
         volumeSliderValue = ariaValueNow / 2.5;
 
         ytVideo.onvolumechange = () => {
-          volumePanel.setAttribute("aria-valuenow", ariaValueNow); 
+          volumePanel.setAttribute("aria-valuenow", ariaValueNow);
           volumePanel.setAttribute("aria-valuetext", `${ariaValueNow}% volume`);
-          volumeSliderHandle.style.left = `${volumeSliderValue}px`; 
+          volumeSliderHandle.style.left = `${volumeSliderValue}px`;
         };
-      }
-      else if(level === "levelDown" && vol > 0.0) {
-        vol = (vol >= minVolume + 0.2) ? (vol - 0.2) : minVolume; 
+      } else if (level === "levelDown" && vol > 0.0) {
+        vol = vol >= minVolume + 0.2 ? vol - 0.2 : minVolume;
         ytVideo.volume = vol;
         ariaValueNow = Math.round(vol / 0.01);
         volumeSliderValue = ariaValueNow / 2.5;
 
         ytVideo.onvolumechange = () => {
-          volumePanel.setAttribute("aria-valuenow", ariaValueNow); 
+          volumePanel.setAttribute("aria-valuenow", ariaValueNow);
           volumePanel.setAttribute("aria-valuetext", `${ariaValueNow}% volume`);
-          volumeSliderHandle.style.left = `${volumeSliderValue}px`; 
+          volumeSliderHandle.style.left = `${volumeSliderValue}px`;
         };
       }
     }
 
     getVolume() {
-      let volumePanel = document.querySelector('.ytp-volume-panel');
-      let vol = parseInt(volumePanel.getAttribute('aria-valuenow'));
-      let isMuted = volumePanel.getAttribute('aria-valuetext').match(/muted/) != null;
-    
+      const volumePanel = document.querySelector(".ytp-volume-panel");
+      const vol = parseInt(volumePanel.getAttribute("aria-valuenow"));
+      const isMuted =
+        volumePanel.getAttribute("aria-valuetext").match(/muted/) !== null;
+
       return isMuted ? 0 : vol;
     }
 
-    action_mute(){
-      if(this.getVolume()) {
-        const muteButton = this.querySelector(`${this.selector} .ytp-mute-button[aria-label^='Mute']`);
+    action_mute() {
+      if (this.getVolume()) {
+        const muteButton = this.querySelector(
+          `${this.selector} .ytp-mute-button[aria-label^='Mute']`
+        );
         muteButton.click();
-      }  
+      }
     }
 
-    action_unmute(){
-      if(! this.getVolume()) {
-        const unmuteButton = this.querySelector(`${this.selector} .ytp-mute-button[aria-label^='Unmute']`);
+    action_unmute() {
+      if (!this.getVolume()) {
+        const unmuteButton = this.querySelector(
+          `${this.selector} .ytp-mute-button[aria-label^='Unmute']`
+        );
         unmuteButton.click();
       }
     }

--- a/extension/services/youtube/player.js
+++ b/extension/services/youtube/player.js
@@ -65,7 +65,7 @@ this.player = (function() {
       const maxVolume = 1.0;
       const minVolume = 0.0;
       const ariaValueFactor = 0.01;
-      const heightFactor = 2.5; 
+      const heightFactor = 2.5;
       const ytVideo = this.querySelector(`${this.selector} .html5-main-video`);
       const volumePanel = this.querySelector(
         `${this.selector} .ytp-volume-panel`
@@ -76,13 +76,16 @@ this.player = (function() {
       let volumeNow = ytVideo.volume;
       let ariaValueNow = parseInt(volumePanel.getAttribute("aria-valuenow"));
       let volumeSliderValue = ariaValueNow / heightFactor;
-      let volumeChange = 0.2;
+      const volumeChange = 0.2;
 
       if (volumeLevel === "levelUp" && volumeNow < maxVolume) {
         if (this.isMuted()) {
           this.action_unmute();
         }
-        volumeNow = volumeNow <= maxVolume - volumeChange ? volumeNow + volumeChange : maxVolume;
+        volumeNow =
+          volumeNow <= maxVolume - volumeChange
+            ? volumeNow + volumeChange
+            : maxVolume;
         ytVideo.volume = volumeNow;
         ariaValueNow = Math.round(volumeNow / ariaValueFactor);
         volumeSliderValue = ariaValueNow / heightFactor;
@@ -93,7 +96,10 @@ this.player = (function() {
           volumeSliderHandle.style.left = `${volumeSliderValue}px`;
         };
       } else if (volumeLevel === "levelDown" && volumeNow > minVolume) {
-        volumeNow = volumeNow >= minVolume + volumeChange ? volumeNow - volumeChange : minVolume;
+        volumeNow =
+          volumeNow >= minVolume + volumeChange
+            ? volumeNow - volumeChange
+            : minVolume;
         ytVideo.volume = volumeNow;
         ariaValueNow = Math.round(volumeNow / ariaValueFactor);
         volumeSliderValue = ariaValueNow / heightFactor;

--- a/extension/services/youtube/player.js
+++ b/extension/services/youtube/player.js
@@ -61,9 +61,11 @@ this.player = (function() {
       button.click();
     }
 
-    action_adjustVolume({ level }) {
+    action_adjustVolume({ volumeLevel }) {
       const maxVolume = 1.0;
       const minVolume = 0.0;
+      const ariaValueFactor = 0.01;
+      const heightFactor = 2.5; 
       const ytVideo = this.querySelector(`${this.selector} .html5-main-video`);
       const volumePanel = this.querySelector(
         `${this.selector} .ytp-volume-panel`
@@ -73,24 +75,28 @@ this.player = (function() {
       );
       let volumeNow = ytVideo.volume;
       let ariaValueNow = parseInt(volumePanel.getAttribute("aria-valuenow"));
-      let volumeSliderValue = ariaValueNow / 2.5;
+      let volumeSliderValue = ariaValueNow / heightFactor;
+      let volumeChange = 0.2;
 
-      if (level === "levelUp" && volumeNow < 1.0) {
-        volumeNow = volumeNow <= maxVolume - 0.2 ? volumeNow + 0.2 : maxVolume;
+      if (volumeLevel === "levelUp" && volumeNow < maxVolume) {
+        if (this.isMuted()) {
+          this.action_unmute();
+        }
+        volumeNow = volumeNow <= maxVolume - volumeChange ? volumeNow + volumeChange : maxVolume;
         ytVideo.volume = volumeNow;
-        ariaValueNow = Math.round(volumeNow / 0.01);
-        volumeSliderValue = ariaValueNow / 2.5;
+        ariaValueNow = Math.round(volumeNow / ariaValueFactor);
+        volumeSliderValue = ariaValueNow / heightFactor;
 
         ytVideo.onvolumechange = () => {
           volumePanel.setAttribute("aria-valuenow", ariaValueNow);
           volumePanel.setAttribute("aria-valuetext", `${ariaValueNow}% volume`);
           volumeSliderHandle.style.left = `${volumeSliderValue}px`;
         };
-      } else if (level === "levelDown" && volumeNow > 0.0) {
-        volumeNow = volumeNow >= minVolume + 0.2 ? volumeNow - 0.2 : minVolume;
+      } else if (volumeLevel === "levelDown" && volumeNow > minVolume) {
+        volumeNow = volumeNow >= minVolume + volumeChange ? volumeNow - volumeChange : minVolume;
         ytVideo.volume = volumeNow;
-        ariaValueNow = Math.round(volumeNow / 0.01);
-        volumeSliderValue = ariaValueNow / 2.5;
+        ariaValueNow = Math.round(volumeNow / ariaValueFactor);
+        volumeSliderValue = ariaValueNow / heightFactor;
 
         ytVideo.onvolumechange = () => {
           volumePanel.setAttribute("aria-valuenow", ariaValueNow);

--- a/extension/services/youtube/player.js
+++ b/extension/services/youtube/player.js
@@ -71,14 +71,14 @@ this.player = (function() {
       const volumeSliderHandle = this.querySelector(
         `${this.selector} .ytp-volume-slider-handle`
       );
-      let vol = ytVideo.volume;
+      let volumeNow = ytVideo.volume;
       let ariaValueNow = parseInt(volumePanel.getAttribute("aria-valuenow"));
       let volumeSliderValue = ariaValueNow / 2.5;
 
-      if (level === "levelUp" && vol < 1.0) {
-        vol = vol <= maxVolume - 0.2 ? vol + 0.2 : maxVolume;
-        ytVideo.volume = vol;
-        ariaValueNow = Math.round(vol / 0.01);
+      if (level === "levelUp" && volumeNow < 1.0) {
+        volumeNow = volumeNow <= maxVolume - 0.2 ? volumeNow + 0.2 : maxVolume;
+        ytVideo.volume = volumeNow;
+        ariaValueNow = Math.round(volumeNow / 0.01);
         volumeSliderValue = ariaValueNow / 2.5;
 
         ytVideo.onvolumechange = () => {
@@ -86,10 +86,10 @@ this.player = (function() {
           volumePanel.setAttribute("aria-valuetext", `${ariaValueNow}% volume`);
           volumeSliderHandle.style.left = `${volumeSliderValue}px`;
         };
-      } else if (level === "levelDown" && vol > 0.0) {
-        vol = vol >= minVolume + 0.2 ? vol - 0.2 : minVolume;
-        ytVideo.volume = vol;
-        ariaValueNow = Math.round(vol / 0.01);
+      } else if (level === "levelDown" && volumeNow > 0.0) {
+        volumeNow = volumeNow >= minVolume + 0.2 ? volumeNow - 0.2 : minVolume;
+        ytVideo.volume = volumeNow;
+        ariaValueNow = Math.round(volumeNow / 0.01);
         volumeSliderValue = ariaValueNow / 2.5;
 
         ytVideo.onvolumechange = () => {
@@ -100,17 +100,15 @@ this.player = (function() {
       }
     }
 
-    getVolume() {
+    isMuted() {
       const volumePanel = document.querySelector(".ytp-volume-panel");
-      const vol = parseInt(volumePanel.getAttribute("aria-valuenow"));
-      const isMuted =
+      const muted =
         volumePanel.getAttribute("aria-valuetext").match(/muted/) !== null;
-
-      return isMuted ? 0 : vol;
+      return muted ? 0 : 1;
     }
 
     action_mute() {
-      if (this.getVolume()) {
+      if (this.isMuted()) {
         const muteButton = this.querySelector(
           `${this.selector} .ytp-mute-button[aria-label^='Mute']`
         );
@@ -119,7 +117,7 @@ this.player = (function() {
     }
 
     action_unmute() {
-      if (!this.getVolume()) {
+      if (!this.isMuted()) {
         const unmuteButton = this.querySelector(
           `${this.selector} .ytp-mute-button[aria-label^='Unmute']`
         );

--- a/extension/services/youtube/player.js
+++ b/extension/services/youtube/player.js
@@ -104,11 +104,11 @@ this.player = (function() {
       const volumePanel = document.querySelector(".ytp-volume-panel");
       const muted =
         volumePanel.getAttribute("aria-valuetext").match(/muted/) !== null;
-      return muted ? 0 : 1;
+      return muted ? 1 : 0;
     }
 
     action_mute() {
-      if (this.isMuted()) {
+      if (!this.isMuted()) {
         const muteButton = this.querySelector(
           `${this.selector} .ytp-mute-button[aria-label^='Mute']`
         );
@@ -117,7 +117,7 @@ this.player = (function() {
     }
 
     action_unmute() {
-      if (!this.isMuted()) {
+      if (this.isMuted()) {
         const unmuteButton = this.querySelector(
           `${this.selector} .ytp-mute-button[aria-label^='Unmute']`
         );

--- a/extension/services/youtube/youtube.js
+++ b/extension/services/youtube/youtube.js
@@ -91,9 +91,9 @@ class YouTube extends serviceList.Service {
     }
   }
 
-  async adjustVolume(level) {
+  async adjustVolume(volumeLevel) {
     await this.initTab("/services/youtube/player.js");
-    await this.callTab("adjustVolume", { level });
+    await this.callTab("adjustVolume", { volumeLevel });
   }
 
   async mute() {

--- a/extension/services/youtube/youtube.js
+++ b/extension/services/youtube/youtube.js
@@ -93,7 +93,7 @@ class YouTube extends serviceList.Service {
 
   async adjustVolume(level) {
     await this.initTab("/services/youtube/player.js");
-    await this.callTab("adjustVolume", {level});
+    await this.callTab("adjustVolume", { level });
   }
 
   async mute() {

--- a/extension/services/youtube/youtube.js
+++ b/extension/services/youtube/youtube.js
@@ -90,6 +90,21 @@ class YouTube extends serviceList.Service {
       await this.callOneTab(tab.id, "move", { direction });
     }
   }
+
+  async adjustVolume(level) {
+    await this.initTab("/services/youtube/player.js");
+    await this.callTab("adjustVolume", {level});
+  }
+
+  async mute() {
+    await this.initTab(`/services/youtube/player.js`);
+    await this.callTab("mute");
+  }
+
+  async unmute() {
+    await this.initTab(`/services/youtube/player.js`);
+    await this.callTab("unmute");
+  }
 }
 
 Object.assign(YouTube, {


### PR DESCRIPTION
Draft PR for #1095 (This PR is covering youtube service for now. I am going to add volume controls for soundcloud and deezer too.)

**Adds** Youtube volume adjustment as per #1095.
**Separates** tab muting from audio/video muting. Already implemented muting; mutes/unmute the tab, sound vanishes but the web player's mute/unmute buttons don't reflect that. Therefore separating mute/unmute for video and music services.

- Adds new intents for `music.volume`, `music.mute` and `music.unmute` in `music.toml`
- Registers all new intents in `music.js`
- Adds `adjustVolume()`, `mute()` and `unmute()` methods in `youtube.js`
- Adds methods for youtube player volume control in `player.js`
- Removes muting the audio, video or music phrases only from `muting.toml`, Adds it to `music.toml`
