### PR TITLE
Fixes #916 restart firefox

### DIFF
--- a/extension/experiments/voice/api.js
+++ b/extension/experiments/voice/api.js
@@ -54,6 +54,10 @@ this.voice = class extends ExtensionAPI {
           async quitApplication() {
             return runCommand("cmd_quitApplication");
           },
+
+          async restorePreviousSession() {
+            return runCommand("Browser:RestoreLastSession");
+          }
         },
       },
     };

--- a/extension/experiments/voice/api.js
+++ b/extension/experiments/voice/api.js
@@ -43,8 +43,16 @@ this.voice = class extends ExtensionAPI {
             return runCommand("History:UndoCloseTab");
           },
 
+          async closeWindow() {
+            return runCommand("cmd_closeWindow");
+          },
+
           async undoCloseWindow() {
             return runCommand("History:UndoCloseWindow");
+          },
+
+          async OpenBrowserWindow() {
+            return runCommand("cmd_newNavigator");
           },
 
           async openDownloads() {
@@ -55,7 +63,7 @@ this.voice = class extends ExtensionAPI {
             return runCommand("cmd_quitApplication");
           },
 
-          async restorePreviousSession() {
+          async restoreLastSession() {
             return runCommand("Browser:RestoreLastSession");
           }
         },

--- a/extension/experiments/voice/schema.json
+++ b/extension/experiments/voice/schema.json
@@ -41,7 +41,16 @@
         "description": "Close Firefox",
         "parameters": [],
         "async": true
+      },
+
+      {
+        "name": "restorePreviousSession",
+        "type": "function",
+        "description": "Restart Firefox",
+        "parameters": [],
+        "async": true
       }
+
     ]
   }
 ]

--- a/extension/experiments/voice/schema.json
+++ b/extension/experiments/voice/schema.json
@@ -20,6 +20,14 @@
       },
 
       {
+        "name": "closeWindow",
+        "type": "function",
+        "description": "Close window",
+        "parameters": [],
+        "async": true
+      },
+
+      {
         "name": "undoCloseWindow",
         "type": "function",
         "description": "Undo close window",
@@ -44,13 +52,20 @@
       },
 
       {
-        "name": "restorePreviousSession",
+        "name": "restoreLastSession",
         "type": "function",
         "description": "Restart Firefox",
         "parameters": [],
         "async": true
-      }
+      },
 
+      {
+        "name": "OpenBrowserWindow",
+        "type": "function",
+        "description": "Open Firefox",
+        "parameters": [],
+        "async": true
+      }
     ]
   }
 ]

--- a/extension/intents/window/window.js
+++ b/extension/intents/window/window.js
@@ -82,8 +82,8 @@ intentRunner.registerIntent({
 intentRunner.registerIntent({
   name: "window.restartApplication",
   async run(context) {
-    await browser.experiments.voice.quitApplication();
-    await browser.windows.create({});
-    await browser.experiments.voice.restorePreviousSession();
+    await browser.experiments.voice.closeWindow();
+    await browser.experiments.voice.OpenBrowserWindow();
+    await browser.experiments.voice.restoreLastSession();
   },
 });

--- a/extension/intents/window/window.js
+++ b/extension/intents/window/window.js
@@ -84,6 +84,6 @@ intentRunner.registerIntent({
   async run(context) {
     await browser.experiments.voice.quitApplication();
     await browser.windows.create({});
-    await browser.experiments.voice.restoreLastSession();
+    await browser.experiments.voice.restorePreviousSession();
   },
 });

--- a/extension/intents/window/window.js
+++ b/extension/intents/window/window.js
@@ -78,3 +78,12 @@ intentRunner.registerIntent({
     await browser.tabs.move(tabsIds, { windowId: currentWindow.id, index: -1 });
   },
 });
+
+intentRunner.registerIntent({
+  name: "window.restartApplication",
+  async run(context) {
+    await browser.experiments.voice.quitApplication();
+    await browser.windows.create({});
+    await browser.experiments.voice.restoreLastSession();
+  },
+});

--- a/extension/intents/window/window.toml
+++ b/extension/intents/window/window.toml
@@ -54,3 +54,12 @@ test = true
 [[window.close.example]]
 phrase = "Close all windows"
 test = true
+
+[window.restartApplication]
+description = "Close Firefox"
+match = """
+  (restart | reopen ) firefox
+"""
+
+[[window.restartApplication.example]]
+phrase = "Restart Firefox"


### PR DESCRIPTION
I  was wondering if there is an existing API for restart @ianb. Cause it seems to me the browser API to shut down firefox makes Firefox itself kill the processes of all extensions.

I am not sure if there's a way to do this outside of child processes. There seems to be no way to do this outside Firefox exposing a browser restart application command to extensions