### PR TITLE
Fix tabs not loading properly when using routines

### DIFF
--- a/extension/browserUtil.js
+++ b/extension/browserUtil.js
@@ -83,8 +83,8 @@ export async function activateTabClickHandler(event) {
 
 export async function createTab(options = {}) {
   const active = await activeTab();
-  if (
-    ["about:blank", "about:home", "about:newtab"].includes(active.url) ||
+  if ((["about:blank", "about:home", "about:newtab"].includes(active.url) &&
+    !(active.status === "loading") && (active.title === "")) ||
     (buildSettings.executeIntentUrl &&
       active.url.startsWith(buildSettings.executeIntentUrl))
   ) {

--- a/extension/browserUtil.js
+++ b/extension/browserUtil.js
@@ -83,8 +83,10 @@ export async function activateTabClickHandler(event) {
 
 export async function createTab(options = {}) {
   const active = await activeTab();
-  if ((["about:blank", "about:home", "about:newtab"].includes(active.url) &&
-    !(active.status === "loading") && (active.title === "")) ||
+  if (
+    (["about:blank", "about:home", "about:newtab"].includes(active.url) &&
+      !(active.status === "loading") &&
+      active.title === "") ||
     (buildSettings.executeIntentUrl &&
       active.url.startsWith(buildSettings.executeIntentUrl))
   ) {


### PR DESCRIPTION
Before submitting a final PR, please:

- [ ] Run `npm test` on your machine
- [x] Run `npm run format` to keep code formatted consistently
- [x] Reference the issue you are fixing in at least one of your commit messages, as `Fixes #X`

Fixes #1365 . Possibly Fixes #1364 and Fixes #1351
@ianb Could you please make out time to review this? The function `createTab` in `browserUtils.js`, decides to reuse an existing tab partly on if the active tab's `url` is `about:blank`. It seems the browser does not immediately resolve the `url` when a new tab is loading, even after the `tab.status` changes to `complete` and the tab is supposedly loaded, it still resolves to `about:blank`. Included a condition to ensure the page is not busy loading and if loaded that it actually has a title. This was the only way I found to test if the page is actually a blank page. It seems Chrome has a `pendingUrl` property in tabs for this reason, but I couldn't get something similar for Firefox. Thanks
