### PR TITLE
Fix google navigation blocking other actions

### DIFF
--- a/extension/background/intentRunner.js
+++ b/extension/background/intentRunner.js
@@ -189,6 +189,10 @@ export class IntentContext {
           // We no longer need to listen for updates:
           browserUtil.onUpdatedRemove(onUpdated, tab.id);
           resolve(tab);
+        } else {
+          // We no longer need to listen for updates:
+          browserUtil.onUpdatedRemove(onUpdated, tab.id);
+          resolve(tab);
         }
       }
       try {

--- a/extension/background/intentRunner.js
+++ b/extension/background/intentRunner.js
@@ -171,7 +171,7 @@ export class IntentContext {
         ) {
           return;
         }
-        const isGoogle = /^https:\/\/www.google.com\//.test(url);
+        const isGoogle = /\/search/.test(url);
         const isRedirect = /^https:\/\/www.google.com\/url\?/.test(url);
         if (!isGoogle || isRedirect) {
           if (isRedirect) {
@@ -186,10 +186,6 @@ export class IntentContext {
             browser.tabs.update(tab.id, { url: newUrl });
             return;
           }
-          // We no longer need to listen for updates:
-          browserUtil.onUpdatedRemove(onUpdated, tab.id);
-          resolve(tab);
-        } else {
           // We no longer need to listen for updates:
           browserUtil.onUpdatedRemove(onUpdated, tab.id);
           resolve(tab);

--- a/extension/intents/clipboard/contentScript.js
+++ b/extension/intents/clipboard/contentScript.js
@@ -110,8 +110,11 @@ this.contentScript = (function() {
     const img = document.querySelectorAll("img");
     let maxHeightIndex = 0;
     img.forEach((element, index) => {
-      if (isInViewport(element) && element.clientHeight > img[maxHeightIndex].clientHeight) {
-          maxHeightIndex = index;
+      if (
+        isInViewport(element) &&
+        element.clientHeight > img[maxHeightIndex].clientHeight
+      ) {
+        maxHeightIndex = index;
       }
     });
     const url = img[maxHeightIndex].src;

--- a/extension/intents/search/search.toml
+++ b/extension/intents/search/search.toml
@@ -131,7 +131,7 @@ test = true
 description = "Give search results from google"
 match = """
   (do a |) (search | search on | query | find | look up | lookup | look on |) (google) (for | for the |) [query] (for me |)
-  (do a |) (search | query | find | look up | lookup | look on | look for |) (for | for the |) [query] (on |) (google) (for me |)
+  (do a |) (search | query | find | look up | lookup | look on | look for |) (for | for the |) [query] (on google) (for me |)
 """
 
 [[search.searchGoogle.example]]


### PR DESCRIPTION
Before submitting a final PR, please:

- [x] Run `npm test` on your machine
- [x] Run `npm run format` to keep code formatted consistently
- [x] Reference the issue you are fixing in at least one of your commit messages, as `Fixes #X`

Fixes #1365
 
@ianb I tried but failed to understand the reason for testing for [google domain](https://github.com/mozilla/firefox-voice/blob/5078ef0840e96e9fe36e2800dbada3f0bf7b1039/extension/background/intentRunner.js#L174) in the `onUpdated` function within the Promise in `createTabGoogleLucky`. Either way it turned out that if a `google.com` url is being loaded the promise never resolves. Introducing an else condition seems to solve this. Am I on the right track?

The utterance `open google` searches for 'open' on google through the `search.searchGoogle` intent instead of using the `navigate.navigate` intent. The matcher in its current state matches phrases like "_Search for cars google_", "_Look for cute kittens google for me_", "_open google_" etc. Modified it to match only when "_on google_" is present. So "_Search for cars on google_" and "_Look for cute kittens on google for me_" will match whereas "_open google_" will not.

Could you please review this? Thanks