### PR TITLE
Fix scrolling not working on some sites

### DIFF
--- a/extension/intents/clipboard/contentScript.js
+++ b/extension/intents/clipboard/contentScript.js
@@ -110,8 +110,11 @@ this.contentScript = (function() {
     const img = document.querySelectorAll("img");
     let maxHeightIndex = 0;
     img.forEach((element, index) => {
-      if (isInViewport(element) && element.clientHeight > img[maxHeightIndex].clientHeight) {
-          maxHeightIndex = index;
+      if (
+        isInViewport(element) &&
+        element.clientHeight > img[maxHeightIndex].clientHeight
+      ) {
+        maxHeightIndex = index;
       }
     });
     const url = img[maxHeightIndex].src;

--- a/extension/intents/scroll/scrollHelper.js
+++ b/extension/intents/scroll/scrollHelper.js
@@ -8,8 +8,12 @@ function getScrollParent(node) {
   }
 
   if (node.scrollHeight > node.clientHeight) {
-    if (node.scrollHeight === node.parentNode.scrollHeight) {
-      return node.parentNode;
+    // if on recursion we get to the body element
+    // body element is not scrollable in firefox, return documentElement
+    // https://developer.mozilla.org/en-US/docs/Web/API/document/scrollingElement
+
+    if (node.tagName === "BODY") {
+      return document.documentElement;
     }
     return node;
   }

--- a/extension/intents/scroll/scrollHelper.js
+++ b/extension/intents/scroll/scrollHelper.js
@@ -12,7 +12,7 @@ function getScrollParent(node) {
     // body element is not scrollable in firefox, return documentElement
     // https://developer.mozilla.org/en-US/docs/Web/API/document/scrollingElement
 
-    if (node.tagName === "BODY") {
+    if (node === document.body) {
       return document.documentElement;
     }
     return node;

--- a/extension/intents/scroll/scrollHelper.js
+++ b/extension/intents/scroll/scrollHelper.js
@@ -8,6 +8,9 @@ function getScrollParent(node) {
   }
 
   if (node.scrollHeight > node.clientHeight) {
+    if (node.scrollHeight === node.parentNode.scrollHeight) {
+      return node.parentNode;
+    }
     return node;
   }
   return getScrollParent(node.parentNode);


### PR DESCRIPTION
Before submitting a final PR, please:

- [x] Run `npm test` on your machine
- [x] Run `npm run format` to keep code formatted consistently
- [x] Reference the issue you are fixing in at least one of your commit messages, as `Fixes #X`

Fixes #1433 

@ianb After some hair pulling, I abandoned the quest to look for a different solution. It turns out the existing solution handles scrolling very well, apart from a few tweaks needed, just as you initially suggested.

Some sites like wikipedia, instagram etc., set their <body> and <html> height to 100%. The scrolling is delegated to the <html>. So the test for scrollable element is bumped up to the parentNode, <html>, for these cases. When you get the chance can you please review this? Thanks
