### PR TITLE
Wakeword

### DIFF
--- a/extension/recorder/wakeword.js
+++ b/extension/recorder/wakeword.js
@@ -63,7 +63,7 @@ function stopWatchword() {
   try {
     porcupineManager.stop();
   } catch (err) {
-    log.error(`Error in porcupine Manager ${err}:`, err);
+    log.error(err);
   }
   log.info("Stopped listening for watchwords");
   enabled = false;

--- a/extension/recorder/wakeword.js
+++ b/extension/recorder/wakeword.js
@@ -60,7 +60,11 @@ function startWatchword(keywords, sensitivity) {
 }
 
 function stopWatchword() {
-  porcupineManager.stop();
+  try {
+    porcupineManager.stop();
+  } catch (err) {
+    log.error(`Error in porcupine Manager ${err}:`, err);
+  }
   log.info("Stopped listening for watchwords");
   enabled = false;
 }


### PR DESCRIPTION
Draft for #1135

I looked into this issue and tried to figure it out. I know that the final result might not be satisfactory, but I've been through several fixes and none seemed to work well so far. 

I realised that the problem was that everytime the error you mentioned appeared, the wakeword stopped working (the user might have to go to the extension tab and refresh it, but even then, sometimes might work, sometimes might not). I placed a try catch around the line that caused the problem to ensure that the code reaches the part that starts the recorder.

I also tried to start the recorder everytime the browser was opened by focusing the wakeword.html tab and refreshing it so that the recorder can load, but then again, this sometimes works and sometimes doesn't (sometimes even after the reload, the user has to interact with the page for the recorder to start). 

Additionally, I tried to place a delay when openWakeword is called in main.js in case wakeword.html wasn't loaded in time. 

@ianb  please take a look at this and tell me if you have a recommendation for another approach