### PR TITLE
Search in hidden tab issue

### DIFF
--- a/extension/intents/search/search.js
+++ b/extension/intents/search/search.js
@@ -36,8 +36,11 @@ async function openSearchTab() {
   }, CLOSE_TIME);
   if (_searchTabId) {
     try {
-      await browser.tabs.get(_searchTabId);
-      return _searchTabId;
+      const tab = await browser.tabs.get(_searchTabId);
+      // reuse tab only if it's hidden
+      if (tab.hidden === true) {
+        return _searchTabId;
+      }
     } catch (e) {
       // Presumably the tab doesn't exist
       log.info("Error getting tab:", String(e));


### PR DESCRIPTION
Fixes #1475

This PR reuses the tab only if it's hidden to avoid both showing the card and searching in page (when the card is available).