### PR TITLE
phrase and example fixes

### DIFF
--- a/extension/intents/browser/browser.toml
+++ b/extension/intents/browser/browser.toml
@@ -67,9 +67,6 @@ match = """
 """
 
 [[browser.preferences.example]]
-phrase = "open settings"
-
-[[browser.preferences.example]]
 phrase = "open firefox settings"
 test = true
 

--- a/extension/intents/tabs/tabs.toml
+++ b/extension/intents/tabs/tabs.toml
@@ -31,7 +31,7 @@ test = true
 [tabs.undoCloseTab]
 description = "Undo close tab"
 match = """
-  (undo | reopen | open | restore | reinstate | bring | recover) (back |) (the | my | that |) (last | recently |) (close | closed |) (tab |)
+  (undo | reopen | restore | reinstate | bring | recover) (back |) (the | my | that |) (last | recently |) (close | closed |) (tab |)
 """
 
 [[tabs.undoCloseTab.example]]
@@ -43,10 +43,6 @@ test = true
 
 [[tabs.undoCloseTab.example]]
 phrase = "Reopen the last closed tab"
-test = true
-
-[[tabs.undoCloseTab.example]]
-phrase = "Open my recently closed tab"
 test = true
 
 [[tabs.undoCloseTab.example]]

--- a/extension/intents/window/window.toml
+++ b/extension/intents/window/window.toml
@@ -75,7 +75,7 @@ phrase = "clear firefox data"
 test = true
 
 [[window.clearBrowserHistory.example]]
-phrase = "clear broswer history"
+phrase = "clear browser history"
 test = true
 
 [window.zoom]


### PR DESCRIPTION
After syncing with latest master, some phrase tests were crashing. 
This PR contains some simple phrase and example fixes to resolve that.

1. One of the phrase match in `[tabs.undoCloseTab]` was colliding with `[tabs.open]`. Therefore removing the keyword 'open' from `[tabs.undoCloseTab]` intent match and also removing the relevant example. 
2. Removing an example from `[browser.preferences]` intent that didn't fulfil the intent match and therefore caught by `[self.openOptions]`.
3. Fixing a misspell in an example in `[window.clearBrowserHistory]` intent, due to which example was unable to match with any intent. 
