### PR TITLE
Fixes #1519: Links to "Things you can say" and "Privacy" result in 404

### DIFF
--- a/extension/options/optionsView.jsx
+++ b/extension/options/optionsView.jsx
@@ -557,7 +557,10 @@ const AboutSection = () => {
           </a>
         </li>
         <li>
-          <a href="https://mozilla.github.io/firefox-voice/privacy-policy.html">
+          <a
+            href="/views/privacy-policy.html"
+            onClick={browserUtil.activateTabClickHandler}
+          >
             How Mozilla Protects Your Voice Privacy
           </a>
         </li>


### PR DESCRIPTION
#1519
Opens the local version of the Privacy Policy so that the resulting links to "Things you can say" and "Privacy" don't result in a 404.