### PR TITLE
music service volume_followup

### DIFF
--- a/extension/background/musicService.js
+++ b/extension/background/musicService.js
@@ -95,9 +95,9 @@ class MusicService extends serviceList.Service {
     }
   }
 
-  async adjustVolume(volumeLevel) {
+  async adjustVolume(inputVolume, volumeLevel) {
     await this.initTab(`/services/${this.id}/player.js`);
-    await this.callTab("adjustVolume", { volumeLevel });
+    await this.callTab("adjustVolume", { inputVolume, volumeLevel });
   }
 
   async mute() {

--- a/extension/intents/music/music.js
+++ b/extension/intents/music/music.js
@@ -139,7 +139,10 @@ intentRunner.registerIntent({
   name: "music.volume",
   async run(context) {
     const service = await getService(context, { lookAtCurrentTab: true });
-    await service.adjustVolume(context.parameters.volumeLevel);
+    await service.adjustVolume(
+      context.slots.inputVolume,
+      context.parameters.volumeLevel
+    );
   },
 });
 

--- a/extension/intents/music/music.toml
+++ b/extension/intents/music/music.toml
@@ -161,14 +161,22 @@ test = true
 description = "Adjust music volume"
 match = """
   (increase | turn up) (music | audio | video |) (volume | the volume) [volumeLevel=levelUp]
-  (make it louder | louder) [volumeLevel=levelUp]
+  (make it louder | louder | volume up) [volumeLevel=levelUp]
   (decrease | turn down) (music | audio | video |) (volume | the volume) [volumeLevel=levelDown]
-  (make it softer | softer) [volumeLevel=levelDown]
+  (make it softer | softer | volume down | lower volume | lower the volume) [volumeLevel=levelDown]
+  set volume (to | by |) [inputVolume] (percent | % |)
+  set [inputVolume] (percent | % |) volume
+  increase volume (to | by ) [inputVolume] (percent | % |) [volumeLevel=levelUp]
+  decrease volume (to | by ) [inputVolume] (percent | % |) [volumeLevel=levelDown]
 """
 
 [[music.volume.example]]
 phrase = "increase volume"
 expectParameters = {volumeLevel = "levelUp"}
+
+[[music.volume.example]]
+phrase = "set volume to 75 percent"
+expectSlots = { inputVolume = "75" }
 
 [music.mute]
 description = "mute music volume"

--- a/extension/services/deezer/player.js
+++ b/extension/services/deezer/player.js
@@ -51,6 +51,14 @@ this.player = (function() {
       }
     }
 
+    getVolumeIcon() {
+      const svgIconGroupBtn = this.querySelectorAll(".svg-icon-group-btn");
+      const volumeBtn = svgIconGroupBtn[svgIconGroupBtn.length - 2];
+      const volumeIcon = volumeBtn.firstElementChild;
+      const volumeIconClass = volumeIcon.getAttribute("class");
+      return volumeIconClass;
+    }
+
     getVolumeSliderTracker() {
       const svgIconGroupBtn = this.querySelectorAll(".svg-icon-group-btn");
       const volumeBtn = svgIconGroupBtn[svgIconGroupBtn.length - 2];
@@ -61,58 +69,86 @@ this.player = (function() {
       });
       volumeBtn.dispatchEvent(mouseover);
       const slidersTrackInput = this.querySelectorAll(".slider-track-input");
-      return slidersTrackInput;
+      return slidersTrackInput[1];
     }
 
-    isMuted() {
-      const slidersTrackInput = this.getVolumeSliderTracker();
+    getVolume() {
+      const sliderTrackInput = this.getVolumeSliderTracker();
       const volumeNow = parseInt(
-        slidersTrackInput[1].getAttribute("aria-valuenow")
+        sliderTrackInput.getAttribute("aria-valuenow")
       );
-      const muted = volumeNow ? 0 : 1;
-      return muted;
+      return volumeNow;
     }
 
-    action_adjustVolume({ volumeLevel }) {
+    action_adjustVolume({ inputVolume = null, volumeLevel = "setInput" }) {
       const maxVolume = 100;
       const minVolume = 0;
-      const volumeChange = 20;
-      const volumeChangeSteps = volumeChange;
-      const slidersTrackInput = this.getVolumeSliderTracker();
-      const volumeNow = parseInt(
-        slidersTrackInput[1].getAttribute("aria-valuenow")
-      );
+      const sliderTrackInput = this.getVolumeSliderTracker();
+      const volumeNow = this.getVolume();
+      let inputVol = 0;
+      let volumeChange = 20;
+      let volumeChangeSteps = volumeChange;
+      let volumeChangeEvent = null;
 
-      if (volumeLevel === "levelUp" && volumeNow < maxVolume) {
-        if (this.isMuted()) {
-          this.action_unmute();
+      if (inputVolume !== null) {
+        if (inputVolume > "0") {
+          inputVol = inputVolume;
+        } else if (inputVolume === "0") {
+          this.action_mute();
+          return;
         }
-        const volumeup = new KeyboardEvent("keypress", {
+        if (volumeLevel === "setInput") {
+          if (volumeNow < inputVol) {
+            volumeLevel = "levelUp";
+          } else if (volumeNow > inputVol) {
+            volumeLevel = "levelDown";
+          }
+        }
+      }
+      if (volumeLevel === "levelUp" && volumeNow < maxVolume) {
+        if (inputVol && volumeNow < inputVol) {
+          volumeChange = inputVol - volumeNow;
+          volumeChangeSteps = volumeChange;
+        }
+        volumeChangeEvent = new KeyboardEvent("keypress", {
           bubbles: true,
           key: "ArrowUp",
           keyCode: 38,
           shiftKey: true,
         });
-        for (let step = 0; step < volumeChangeSteps; step++) {
-          slidersTrackInput[1].dispatchEvent(volumeup);
-        }
       } else if (volumeLevel === "levelDown" && volumeNow > minVolume) {
-        const volumedown = new KeyboardEvent("keypress", {
+        if (inputVol && volumeNow > inputVol) {
+          volumeChange = volumeNow - inputVol;
+          volumeChangeSteps = volumeChange;
+        }
+        volumeChangeEvent = new KeyboardEvent("keypress", {
           bubbles: true,
           key: "ArrowDown",
           keyCode: 40,
           shiftKey: true,
         });
-        for (let step = 0; step < volumeChangeSteps; step++) {
-          slidersTrackInput[1].dispatchEvent(volumedown);
-        }
       }
+      if (this.isMuted()) {
+        this.action_unmute();
+      }
+      for (let step = 0; step < volumeChangeSteps; step++) {
+        sliderTrackInput.dispatchEvent(volumeChangeEvent);
+      }
+      if (this.getVolume() === 0) {
+        this.action_mute();
+      }
+    }
+
+    isMuted() {
+      const volumeIcon = this.getVolumeIcon();
+      const muted = volumeIcon === "svg-icon svg-icon-volume-off" ? 1 : 0;
+      return muted;
     }
 
     action_mute() {
       if (!this.isMuted()) {
         const iconVolume = this.querySelector(".svg-icon-volume");
-        const iconVolumeParent = iconVolume.closest(".svg-icon-group-btn");
+        const iconVolumeParent = iconVolume.parentElement;
         iconVolumeParent.click();
       }
     }
@@ -120,7 +156,7 @@ this.player = (function() {
     action_unmute() {
       if (this.isMuted()) {
         const iconVolumeOff = this.querySelector(".svg-icon-volume-off");
-        const iconVolumeParent = iconVolumeOff.closest(".svg-icon-group-btn");
+        const iconVolumeParent = iconVolumeOff.parentElement;
         iconVolumeParent.click();
       }
     }

--- a/extension/services/soundcloud/player.js
+++ b/extension/services/soundcloud/player.js
@@ -42,38 +42,61 @@ this.player = (function() {
       }
     }
 
-    action_adjustVolume({ volumeLevel }) {
+    action_adjustVolume({ inputVolume = null, volumeLevel = "setInput" }) {
       const maxVolume = 1.0;
       const minVolume = 0.0;
       const volumeChangeReceiver = this.querySelector(".volume");
       const sliderWrapper = this.querySelector(".volume__sliderWrapper");
       const volumeNow = parseFloat(sliderWrapper.getAttribute("aria-valuenow"));
-      const volumeChange = 0.2;
-      const volumeChangeSteps = volumeChange * 10;
+      let inputVol = 0.0;
+      let volumeChange = 0.2;
+      let volumeChangeSteps = volumeChange * 10;
+      let volumeChangeEvent = null;
+
+      if (inputVolume !== null) {
+        if (inputVolume > "0") {
+          inputVol = (inputVolume / 100).toPrecision(2);
+        } else if (inputVolume === "0") {
+          this.action_mute();
+          return;
+        }
+        if (volumeLevel === "setInput") {
+          if (volumeNow < inputVol) {
+            volumeLevel = "levelUp";
+          } else if (volumeNow > inputVol) {
+            volumeLevel = "levelDown";
+          }
+        }
+      }
 
       if (volumeLevel === "levelUp" && volumeNow < maxVolume) {
-        if (this.isMuted()) {
-          this.action_unmute();
+        if (inputVol && volumeNow < inputVol) {
+          volumeChange = inputVol - volumeNow;
+          volumeChangeSteps = volumeChange * 10;
         }
-        const volumeup = new KeyboardEvent("keydown", {
+        volumeChangeEvent = new KeyboardEvent("keydown", {
           bubbles: true,
           key: "ArrowUp",
           keyCode: 38,
           shiftKey: true,
         });
-        for (let step = 0; step < volumeChangeSteps; step++) {
-          volumeChangeReceiver.dispatchEvent(volumeup);
-        }
       } else if (volumeLevel === "levelDown" && volumeNow > minVolume) {
-        const volumedown = new KeyboardEvent("keydown", {
+        if (inputVol && volumeNow > inputVol) {
+          volumeChange = volumeNow - inputVol;
+          volumeChangeSteps = volumeChange * 10;
+        }
+        volumeChangeEvent = new KeyboardEvent("keydown", {
           bubbles: true,
           key: "ArrowDown",
           keyCode: 40,
           shiftKey: true,
         });
-        for (let step = 0; step < volumeChangeSteps; step++) {
-          volumeChangeReceiver.dispatchEvent(volumedown);
-        }
+      }
+      if (this.isMuted()) {
+        this.action_unmute();
+      }
+      for (let step = 0; step < volumeChangeSteps; step++) {
+        volumeChangeReceiver.dispatchEvent(volumeChangeEvent);
       }
     }
 

--- a/extension/services/youtube/youtube.js
+++ b/extension/services/youtube/youtube.js
@@ -105,9 +105,9 @@ class YouTube extends serviceList.Service {
     }
   }
 
-  async adjustVolume(volumeLevel) {
+  async adjustVolume(inputVolume, volumeLevel) {
     await this.initTab("/services/youtube/player.js");
-    await this.callTab("adjustVolume", { volumeLevel });
+    await this.callTab("adjustVolume", { inputVolume, volumeLevel });
   }
 
   async mute() {


### PR DESCRIPTION
This PR adds youtube, soundcloud and deezer volume controls to be handled as numbers or percentages (1-100) as [suggested here](https://github.com/mozilla/firefox-voice/pull/1375#discussion_r398201903). Along with some code improvements to my previous code.
I am dealing numbers and percents as alias to keep things simple. 

Also Fixes #1501 
