### PR TITLE
Add timer followup

### DIFF
--- a/extension/background/intentRunner.js
+++ b/extension/background/intentRunner.js
@@ -170,6 +170,7 @@ export class IntentContext {
       utterance,
       fallback: false,
       isFollowup: true,
+      followupMatch: lastIntentForFollowup.followupMatch,
     };
   }
 
@@ -341,6 +342,11 @@ export function registerIntent(intent) {
     throw new Error(`Intent missing .match: ${intent.name}`);
   }
   intentParser.registerMatcher(intent.name, intent.match);
+}
+
+export function setLastIntent(intent) {
+  lastIntent = intent;
+  lastIntentForFollowup = intent;
 }
 
 export async function runUtterance(utterance, noPopup) {

--- a/extension/intents/timer/timer.toml
+++ b/extension/intents/timer/timer.toml
@@ -7,6 +7,11 @@ match = """
 [[timer.set.example]]
 phrase = "Set timer for 2 hours and 5 minutes"
 
+[timer.set.followup]
+match = """
+    reset (timer |)
+"""
+
 
 [timer.close]
 description = "Close timer"

--- a/extension/popup/popupController.jsx
+++ b/extension/popup/popupController.jsx
@@ -116,7 +116,7 @@ export const PopupController = function() {
       }
 
       if (waitFor < 0) {
-        clearTimer(totalInMS);
+        clearTimer({ totalInMS });
       }
     }
 
@@ -251,7 +251,7 @@ export const PopupController = function() {
         return Promise.resolve(true);
       }
       case "closeTimer": {
-        clearTimer(message.totalInMS);
+        clearTimer(message);
         return Promise.resolve(true);
       }
       default:
@@ -260,14 +260,12 @@ export const PopupController = function() {
     return undefined;
   };
 
-  const clearTimer = async totalInMS => {
+  const clearTimer = async ({ totalInMS, followup }) => {
+    playTimerAlarm();
     setPopupView("timer");
 
     // use this variable to stop any other actions and show notifications
     timerElapsed = true;
-
-    cancelRecoder();
-    playTimerAlarm();
 
     setTranscript("Time's up");
 
@@ -281,7 +279,14 @@ export const PopupController = function() {
       method: "closeActiveTimer",
     });
 
-    closePopup();
+    if (followup) {
+      setFollowupText(followup);
+      setRequestFollowup(true);
+      runFollowup();
+    } else {
+      cancelRecoder();
+      closePopup();
+    }
   };
 
   const startTimer = async duration => {
@@ -505,6 +510,7 @@ export const PopupController = function() {
     if (renderListenComponent) {
       renderListenComponent = false;
     }
+    forceCancelRecoder = false;
     recorder.startRecording();
     closePopup(FOLLOWUP_TIMEOUT);
   };

--- a/extension/popup/popupView.jsx
+++ b/extension/popup/popupView.jsx
@@ -280,7 +280,6 @@ const PopupContent = ({
           <TimerCard
             timerInMS={timerInMS}
             timerTotalInMS={timerTotalInMS}
-            onSubmitFeedback={onSubmitFeedback}
           ></TimerCard>
         );
       default:
@@ -315,12 +314,21 @@ const FollowupContainer = ({ followupText, renderFollowup, currentView }) => {
   return (
     <div id="followup-container">
       <IntentFeedback />
-      <div id="followup-wrapper">
-        <div id="followup_mic-container">Mic On</div>
-        <div id="followup_headings-wrapper">
-          <div id="followup_heading">{heading}</div>
-          {subheading && <div id="followup_subheading">{subheading}</div>}
-        </div>
+      <FollowUpWrapper
+        heading={heading}
+        subheading={subheading}
+      ></FollowUpWrapper>
+    </div>
+  );
+};
+
+const FollowUpWrapper = ({ heading, subheading }) => {
+  return (
+    <div id="followup-wrapper">
+      <div id="followup_mic-container">Mic On</div>
+      <div id="followup_headings-wrapper">
+        <div id="followup_heading">{heading}</div>
+        {subheading && <div id="followup_subheading">{subheading}</div>}
       </div>
     </div>
   );
@@ -430,7 +438,7 @@ const parseTimer = timerInMS => {
   return pad(minutes, 2) + ":" + pad(seconds, 2);
 };
 
-const TimerCard = ({ timerInMS, timerTotalInMS, onSubmitFeedback }) => {
+const TimerCard = ({ timerInMS, timerTotalInMS }) => {
   const getNotificationExpression = timerTotalInMS => {
     const { hours, minutes, seconds } = getHourMinuteSecond(timerTotalInMS);
     let expression = "";
@@ -465,7 +473,6 @@ const TimerCard = ({ timerInMS, timerTotalInMS, onSubmitFeedback }) => {
           {timerInMS <= 0 ? <p>{notificationExpression}</p> : null}
         </div>
       </div>
-      <IntentFeedback onSubmitFeedback={onSubmitFeedback} />
     </React.Fragment>
   );
 };


### PR DESCRIPTION
Fixes #1392

In this PR:
-> I fixed a display issue with timer when feedback card appeared (after followups were merged, there were 2 feedback cards).

-> added the follow-up functionality for reset and close; Now, the user can say "close timer" within 5 seconds of the input command (as long as the followup stays awake), or when the timer finished, "reset | reset timer".

@ianb  please take a look :) 

