### PR TITLE
display message instead of internal error for saveAsPDF

### DIFF
--- a/extension/intents/tabs/tabs.js
+++ b/extension/intents/tabs/tabs.js
@@ -151,10 +151,9 @@ intentRunner.registerIntent({
     // "canceled"
     // "not_saved"
     // "not_replaced"
-    try{
+    try {
       await browser.tabs.saveAsPDF({});
-    }
-    catch (e) {
+    } catch (e) {
       if (e.message === "Not supported on Mac OS X") {
         e.displayMessage = "Save as PDF is not supported on Mac OS X";
         throw e;

--- a/extension/intents/tabs/tabs.js
+++ b/extension/intents/tabs/tabs.js
@@ -151,7 +151,15 @@ intentRunner.registerIntent({
     // "canceled"
     // "not_saved"
     // "not_replaced"
-    await browser.tabs.saveAsPDF({});
+    try{
+      await browser.tabs.saveAsPDF({});
+    }
+    catch (e) {
+      if (e.message === "Not supported on Mac OS X") {
+        e.displayMessage = "Save as PDF is not supported on Mac OS X";
+        throw e;
+      }
+    }
   },
 });
 


### PR DESCRIPTION
`tabs.saveAsPDF()` is not supported for mac OS and it shows internal error in doorhanger.
This PR adds try catch block to display message to the user instead of displaying internal error.