### PR TITLE
fixes #1548 "Zoom window" gives "Internal error

### DIFF
--- a/extension/experiments/voice/api.js
+++ b/extension/experiments/voice/api.js
@@ -86,10 +86,6 @@ this.voice = class extends ExtensionAPI {
             return runCommand("View:PageSource");
           },
 
-          async zoomWindow() {
-            return runCommand("zoomWindow");
-          },
-
           async minimizeWindow() {
             return runCommand("minimizeWindow");
           },

--- a/extension/experiments/voice/schema.json
+++ b/extension/experiments/voice/schema.json
@@ -123,14 +123,6 @@
       },
 
       {
-        "name": "zoomWindow",
-        "type": "function",
-        "description": "Zoom Firefox",
-        "parameters": [],
-        "async": true
-      },
-
-      {
         "name": "minimizeWindow",
         "type": "function",
         "description": "Minimize Firefox",

--- a/extension/intents/tabs/tabs.js
+++ b/extension/intents/tabs/tabs.js
@@ -231,19 +231,6 @@ intentRunner.registerIntent({
   },
 });
 
-intentRunner.registerIntent({
-  name: "tabs.maximize",
-  async run(context) {
-    if (buildSettings.android) {
-      const exc = new Error("Maximize not supported on Android");
-      exc.displayMessage = exc.message;
-      throw exc;
-    }
-    const currentWindow = await browser.windows.getCurrent();
-    await browser.windows.update(currentWindow.id, { state: "maximized" });
-  },
-});
-
 const tabHistory = [];
 let lastActivate;
 

--- a/extension/intents/tabs/tabs.toml
+++ b/extension/intents/tabs/tabs.toml
@@ -94,15 +94,6 @@ match = """
 [[tabs.fullScreen.example]]
 phrase = "full screen"
 
-[tabs.maximize]
-description = "Maximize window"
-match = """
-  maximize (the | this |) (window |)
-"""
-
-[[tabs.maximize.example]]
-phrase = "maximize"
-
 [tabs.moveToWindow]
 description = "Move tab in a new window"
 match = """

--- a/extension/intents/window/window.js
+++ b/extension/intents/window/window.js
@@ -1,3 +1,5 @@
+/* globals buildSettings */
+
 import * as intentRunner from "../../background/intentRunner.js";
 
 function findTargetWindowId(windowArray, currentWindowId, direction) {
@@ -75,7 +77,13 @@ intentRunner.registerIntent({
 intentRunner.registerIntent({
   name: "window.zoom",
   async run(context) {
-    await browser.experiments.voice.zoomWindow();
+    if (buildSettings.android) {
+      const exc = new Error("Maximize not supported on Android");
+      exc.displayMessage = exc.message;
+      throw exc;
+    }
+    const currentWindow = await browser.windows.getCurrent();
+    await browser.windows.update(currentWindow.id, { state: "maximized" });
   },
 });
 

--- a/extension/intents/window/window.toml
+++ b/extension/intents/window/window.toml
@@ -81,7 +81,7 @@ test = true
 [window.zoom]
 description = "Zooms the window"
 match = """
-  zoom (the |) (this |) window (for me |)
+  (Zoom | Maximize |) (the | this |) (window |) (for me |)
 """
 
 [[window.zoom.example]]
@@ -89,6 +89,14 @@ phrase = "Zoom window"
 
 [[window.zoom.example]]
 phrase = "Zoom this window"
+test = true
+
+[[window.zoom.example]]
+phrase = "Maximize window"
+test = true
+
+[[window.zoom.example]]
+phrase = "Maximize"
 test = true
 
 [window.minimize]


### PR DESCRIPTION
It appears the browser runCommand "zoomWindow" does not work on windows. I do not have this tested on a windows machine but from the issue raised in #1548, "maximize window" calls the command which changes windows state to maximized. This works on a mac, I believe an alias which calls the same command "maximize window" calls fixes it for a windows machine
