### PR TITLE
Fix #1526, allow google I'm lucky requests to continue through redirect

### DIFF
--- a/extension/background/intentRunner.js
+++ b/extension/background/intentRunner.js
@@ -241,8 +241,8 @@ export class IntentContext {
     const searchUrl = searching.googleSearchUrl(query, true);
     const tab =
       !!options.openInTabId && options.openInTabId > -1
-        ? await browserUtil.loadUrl(options.openInTabId, searchUrl)
-        : await this.createTab({ url: searchUrl });
+        ? await browser.tabs.update(options.openInTabId, { url: searchUrl })
+        : await browserUtil.createTab({ url: searchUrl });
     if (options.hide && !buildSettings.android) {
       await browser.tabs.hide(tab.id);
     }


### PR DESCRIPTION
This removes use of loadUrl (directly or indirectly) in the function, which doesn't understand redirects

Before submitting a final PR, please:

- [ ] Run `npm test` on your machine
- [ ] Run `npm run format` to keep code formatted consistently
- [ ] Reference the issue you are fixing in at least one of your commit messages, as `Fixes #X`
