### PR TITLE
Fix #1149, add audio onboarding

### DIFF
--- a/extension/onboarding/onboardingController.jsx
+++ b/extension/onboarding/onboardingController.jsx
@@ -9,6 +9,8 @@ const onboardingContainer = document.getElementById("onboarding-container");
 let isInitialized = false;
 let userSettings;
 
+const askForAudio = !!new URLSearchParams(location.search).get("audio");
+
 export const OnboardingController = function() {
   const [optinViewAlreadyShown, setOptinViewShown] = useState(true);
   const [permissionError, setPermissionError] = useState(null);
@@ -32,6 +34,9 @@ export const OnboardingController = function() {
   const setOptinValue = async value => {
     userSettings.collectTranscriptsOptinAnswered = Date.now();
     userSettings.utterancesTelemetry = value;
+    if (askForAudio) {
+      userSettings.collectAudio = value;
+    }
     await settings.saveSettings(userSettings);
   };
 
@@ -56,6 +61,7 @@ export const OnboardingController = function() {
   return (
     <onboardingView.Onboarding
       optinViewAlreadyShown={optinViewAlreadyShown}
+      askForAudio={askForAudio}
       setOptinValue={setOptinValue}
       setOptinViewShown={setOptinViewShown}
       permissionError={permissionError}

--- a/extension/onboarding/onboardingView.jsx
+++ b/extension/onboarding/onboardingView.jsx
@@ -5,6 +5,7 @@ import * as browserUtil from "../browserUtil.js";
 
 export const Onboarding = ({
   optinViewAlreadyShown,
+  askForAudio,
   setOptinValue,
   setOptinViewShown,
   permissionError,
@@ -15,6 +16,7 @@ export const Onboarding = ({
         <OptinVoiceTranscripts
           setOptinValue={setOptinValue}
           setOptinViewShown={setOptinViewShown}
+          askForAudio={askForAudio}
         />
       )}
       {optinViewAlreadyShown && permissionError && (
@@ -30,7 +32,11 @@ export const Onboarding = ({
   );
 };
 
-const OptinVoiceTranscripts = ({ setOptinValue, setOptinViewShown }) => {
+const OptinVoiceTranscripts = ({
+  setOptinValue,
+  setOptinViewShown,
+  askForAudio,
+}) => {
   const updateVoiceTranscriptOptin = event => {
     event.preventDefault();
     setOptinValue(!!event.target.value);
@@ -42,31 +48,17 @@ const OptinVoiceTranscripts = ({ setOptinValue, setOptinViewShown }) => {
       <div className="modal">
         <div className="modal-header">
           <p>Successfully Installed</p>
-          <h1>Allow Firefox Voice to Collect Voice Transcripts</h1>
+          {askForAudio ? (
+            <h1>Allow Firefox Voice to collect Voice Samples</h1>
+          ) : (
+            <h1>Allow Firefox Voice to Collect Voice Transcripts</h1>
+          )}
         </div>
-        <div className="modal-content">
-          <p>
-            For research purposes and in order to improve Firefox Voice and
-            related services, Mozilla would like to collect and analyze voice
-            transcripts. We store this data securely and without personally
-            identifying information. Can Firefox Voice store transcripts of your
-            voice recordings for research?
-          </p>
-          <p>
-            You’ll always be able to use Firefox Voice, even if you don’t allow
-            collection. The microphone is only active when triggered with a
-            button press or keyboard shortcut.
-          </p>
-          <p>
-            <a
-              href="/views/privacy-policy.html"
-              target="_blank"
-              onClick={browserUtil.activateTabClickHandler}
-            >
-              Learn how Mozilla protects your voice data.
-            </a>
-          </p>
-        </div>
+        {askForAudio ? (
+          <OptinAudioDescription />
+        ) : (
+          <OptinVoiceTranscriptsDescription />
+        )}
         <div className="modal-footer">
           <button
             className="styled-button"
@@ -83,6 +75,61 @@ const OptinVoiceTranscripts = ({ setOptinValue, setOptinViewShown }) => {
           </button>
         </div>
       </div>
+    </div>
+  );
+};
+
+const OptinAudioDescription = () => {
+  return (
+    <div className="modal-content">
+      <p>
+        At Mozilla we’re trying to build an open voice ecosystem that is private
+        and secure. To do this we need to collect the necessary data to teach
+        our systems how to recognize a wider variety of diverse voices, in all
+        sorts of environments.
+      </p>
+      <p>Will you allow Firefox Voice to store your voice recordings?</p>
+      <p>
+        You’ll always be able to use Firefox Voice, even if you don’t allow
+        collection.
+      </p>
+      <p>
+        <a
+          href="/views/privacy-policy.html"
+          target="_blank"
+          onClick={browserUtil.activateTabClickHandler}
+        >
+          Learn how Mozilla protects your voice data.
+        </a>
+      </p>
+    </div>
+  );
+};
+
+const OptinVoiceTranscriptsDescription = () => {
+  return (
+    <div className="modal-content">
+      <p>
+        For research purposes and in order to improve Firefox Voice and related
+        services, Mozilla would like to collect and analyze voice transcripts.
+        We store this data securely and without personally identifying
+        information. Can Firefox Voice store transcripts of your voice
+        recordings for research?
+      </p>
+      <p>
+        You’ll always be able to use Firefox Voice, even if you don’t allow
+        collection. The microphone is only active when triggered with a button
+        press or keyboard shortcut.
+      </p>
+      <p>
+        <a
+          href="/views/privacy-policy.html"
+          target="_blank"
+          onClick={browserUtil.activateTabClickHandler}
+        >
+          Learn how Mozilla protects your voice data.
+        </a>
+      </p>
     </div>
   );
 };

--- a/extension/popup/popupController.jsx
+++ b/extension/popup/popupController.jsx
@@ -78,7 +78,7 @@ export const PopupController = function() {
     userSettingsPromise.resolve(userSettings);
     if (!userSettings.collectTranscriptsOptinAnswered) {
       log.info("Opening onboard to force opt-in/out to transcripts");
-      await browserUtil.openOrActivateTab("onboarding/onboard.html");
+      await browser.runtime.sendMessage({ type: "launchOnboarding" });
       window.close();
       return;
     }
@@ -610,9 +610,7 @@ export const PopupController = function() {
   };
 
   const startOnboarding = async () => {
-    await browser.tabs.create({
-      url: browser.extension.getURL("onboarding/onboard.html"),
-    });
+    return browser.runtime.sendMessage({ type: "launchOnboarding" });
   };
 
   const sendFeedback = async feedback => {


### PR DESCRIPTION
This includes both transcript and audio opt-in, and chooses which one to ask for based on the presence of an installation page.

An installation page must either:
* Have `?source=commonvoice`
* Have `?ask-audio=1`

This looks like:
<img width="1392" alt="Screen Shot 2020-04-27 at 4 52 57 PM" src="https://user-images.githubusercontent.com/44390/80426461-57ad9400-88ab-11ea-9ecb-dd8e2e7ef8ef.png">

To test:
* Run `rm -rf Profile` to start from a scratch profile
* Open https://voice.mozilla.org/firefox-voice/?source=commonvoice or https://voice.mozilla.org/firefox-voice/?ask-audio=1
* Close any onboarding page you have open
* Click the popup to re-open onboarding

Note language is still provisional.

/cc @awallin 