### PR TITLE
Update web-ext to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "stylelint-config-standard": "^18.3.0",
     "stylelint-prettier": "^1.1.1",
     "toml": "^3.0.0",
-    "web-ext": "^3.1.1"
+    "web-ext": "^4.2.0"
   },
   "dependencies": {
     "@sentry/browser": "^5.6.3",


### PR DESCRIPTION
This will fix a problem with npm start not working on latest Nightlies
