### PR TITLE
fixes #1552 added consistent bookmark alias

### DIFF
--- a/extension/intents/browser/browser.toml
+++ b/extension/intents/browser/browser.toml
@@ -1,7 +1,7 @@
 [browser.bookmark]
 description = "Open bookmarks"
 match = """
-  (Open | show | View |) (all | my |) (bookmark{s} |) (sidebar |)
+  (Open | show |) (all | my |) (bookmark{s} |)
 """
 
 [[browser.bookmark.example]]
@@ -21,10 +21,6 @@ test = true
 
 [[browser.bookmark.example]]
 phrase = "Show my bookmark{s}"
-test = true
-
-[[browser.bookmark.example]]
-phrase = "View bookmark{s} sidebar"
 test = true
 
 [browser.history]

--- a/extension/intents/sidebar/sidebar.toml
+++ b/extension/intents/sidebar/sidebar.toml
@@ -1,12 +1,17 @@
 [sidebar.openSidebar]
 description = "Open the sidebar with Bookmarks or History"
 match = """
-  (open | show |) (my | the |) bookmark{s} sidebar (for me|) [sidebar=bookmarks]
+  (open | show | view |) (my | the |) bookmark{s} sidebar (for me|) [sidebar=bookmarks]
   (open | show |) (my | the |) history sidebar (for me|) [sidebar=history]
 """
 
 [[sidebar.openSidebar.example]]
-phrase = "open bookmarks sidebar"
+phrase = "Open bookmarks sidebar"
+expectParameters = {sidebar = "bookmarks"}
+
+[[sidebar.openSidebar.example]]
+phrase = "view bookmark{s} sidebar"
+test = true
 expectParameters = {sidebar = "bookmarks"}
 
 [sidebar.closeSidebar]


### PR DESCRIPTION
As noted by @alexandra-martin the alternative `(sidebar |)` might be blocking for the `sidebar.openSidebar` command and for a good consistency between the commands `view bookmark{s} sidebar` is being moved.

@ianb could you review please?