### PR TITLE
Fix #1656, implement new two-step opt-in flow

### DIFF
--- a/extension/onboarding/onboardingController.jsx
+++ b/extension/onboarding/onboardingController.jsx
@@ -13,6 +13,9 @@ const askForAudio = !!new URLSearchParams(location.search).get("audio");
 
 export const OnboardingController = function() {
   const [optinViewAlreadyShown, setOptinViewShown] = useState(true);
+  const [optinTechDataAlreadyShown, setOptinTechDataAlreadyShown] = useState(
+    true
+  );
   const [permissionError, setPermissionError] = useState(null);
 
   useEffect(() => {
@@ -25,9 +28,27 @@ export const OnboardingController = function() {
   const init = async () => {
     userSettings = await settings.getSettings();
     setOptinViewShown(!!userSettings.collectTranscriptsOptinAnswered);
-
+    setOptinTechDataAlreadyShown(
+      !!userSettings.collectTranscriptsOptinAnswered
+    );
     if (optinViewAlreadyShown) {
       launchPermission();
+    }
+  };
+
+  const setCollectTechData = async value => {
+    if (!value) {
+      // Opting out of tech data means opting out of everything
+      userSettings.collectTranscriptsOptinAnswered = Date.now();
+      userSettings.disableTelemetry = true;
+      setOptinTechDataAlreadyShown(true);
+      // This is true, in that we don't have to show the second opt-in view:
+      setOptinViewShown(true);
+      await settings.saveSettings(userSettings);
+    } else {
+      userSettings.disableTelemetry = false;
+      setOptinTechDataAlreadyShown(true);
+      await settings.saveSettings(userSettings);
     }
   };
 
@@ -61,7 +82,9 @@ export const OnboardingController = function() {
   return (
     <onboardingView.Onboarding
       optinViewAlreadyShown={optinViewAlreadyShown}
+      optinTechDataAlreadyShown={optinTechDataAlreadyShown}
       askForAudio={askForAudio}
+      setCollectTechData={setCollectTechData}
       setOptinValue={setOptinValue}
       setOptinViewShown={setOptinViewShown}
       permissionError={permissionError}

--- a/extension/onboarding/onboardingView.jsx
+++ b/extension/onboarding/onboardingView.jsx
@@ -4,30 +4,81 @@
 import * as browserUtil from "../browserUtil.js";
 
 export const Onboarding = ({
+  optinTechDataAlreadyShown,
   optinViewAlreadyShown,
   askForAudio,
+  setCollectTechData,
   setOptinValue,
   setOptinViewShown,
   permissionError,
 }) => {
   return (
     <div id="onboarding-wrapper">
-      {!optinViewAlreadyShown && (
+      {!optinViewAlreadyShown && !optinTechDataAlreadyShown ? (
+        <OptinTechData setCollectTechData={setCollectTechData} />
+      ) : null}
+      {!optinViewAlreadyShown && optinTechDataAlreadyShown ? (
         <OptinVoiceTranscripts
           setOptinValue={setOptinValue}
           setOptinViewShown={setOptinViewShown}
           askForAudio={askForAudio}
         />
-      )}
-      {optinViewAlreadyShown && permissionError && (
+      ) : null}
+      {optinViewAlreadyShown && permissionError ? (
         <PermissionError permissionError={permissionError} />
-      )}
-      {optinViewAlreadyShown && !permissionError && (
+      ) : null}
+      {optinViewAlreadyShown && !permissionError ? (
         <React.Fragment>
           <OnboardingPageContent />
           <Footer />
         </React.Fragment>
-      )}
+      ) : null}
+    </div>
+  );
+};
+
+const OptinTechData = ({ setCollectTechData }) => {
+  const updateTechData = event => {
+    event.preventDefault();
+    setCollectTechData(!!event.target.value);
+  };
+  return (
+    <div id="optinTechData" className="modal-wrapper">
+      <div className="modal">
+        <div className="modal-header">
+          <p>Successfully Installed</p>
+          <h1>
+            Allow Firefox Voice to send technical and interaction data to
+            Mozilla?
+          </h1>
+        </div>
+        <div className="modal-content">
+          <p>
+            This includes high-level categorizations of requests (e.g., search,
+            close tab, and play music) and error reports. Changes to this
+            setting can be made any time in preferences.
+          </p>
+          <p>
+            Data is stored securely and without personally identifying
+            information.
+          </p>
+        </div>
+        <div className="modal-footer">
+          <button
+            className="styled-button"
+            onClick={updateTechData}
+            value={true}
+          >
+            Allow
+          </button>
+          <button
+            className="styled-button cancel-button"
+            onClick={updateTechData}
+          >
+            Don't allow
+          </button>
+        </div>
+      </div>
     </div>
   );
 };
@@ -47,7 +98,6 @@ const OptinVoiceTranscripts = ({
     <div id="optinVoiceTranscripts" className="modal-wrapper">
       <div className="modal">
         <div className="modal-header">
-          <p>Successfully Installed</p>
           {askForAudio ? (
             <h1>Allow Firefox Voice to collect Voice Samples</h1>
           ) : (


### PR DESCRIPTION
Language and designs aren't final, but this implements the flow:

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/44390/82256545-278e6980-991c-11ea-82a6-d81418d58483.png">

If you click Don't allow, then it goes right to onboarding (all telemetry turned off), otherwise you get the same screen as before:

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/44390/82256588-3bd26680-991c-11ea-8c16-b5ad0e5b49a8.png">
