### PR TITLE
Fix #1655, update privacy policy

### DIFF
--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -2,9 +2,7 @@
 
 May, 2020
 
-The [Mozilla Privacy Policy](https://www.mozilla.org/en-US/privacy/) applies to Firefox Voice, and this Notice provides additional information about what Firefox Voice collects and how we might share it.
-
-Here are the things you should know about Firefox Voice:
+This Notice provides information about what Firefox Voice collects and how we might share it.
 
 ## Information we collect
 
@@ -13,13 +11,16 @@ Here are the things you should know about Firefox Voice:
 To help us improve Firefox Voice, you may choose to allow Mozilla to store your voice commands and transcripts of your commands. We store this data without personally identifiable information, which means we don’t know who said them.
 
 **Interaction data**: Mozilla receives technical data from Firefox Voice related to performance of the feature, such as browser type and time needed to process submitted recordings.
-Technical data: Mozilla receives metrics information including the number of voice samples recorded, session length and outcome, results provided by Firefox Voice, and whether those results are modified or selected.
+
+**Technical data**: Mozilla receives metrics information including the number of voice samples recorded, session length and outcome, results provided by Firefox Voice, and whether those results are modified or selected.
 
 ## Information we share
 
-As described in our privacy policy, Firefox Voice shares data with service providers to provide and improve our services.
+Firefox Voice shares data with service providers to provide and improve our services.
 
 Here’s who we use to support Firefox Voice:
 
-- [Google Cloud Speech Service](https://cloud.google.com/terms/data-processing-terms): we share your audio recording with Google Cloud’s speech-to-text service to assist us in processing and carrying out your commands. Audio recordings are shared without personally identifiable metadata, and we've instructed Google's service not to retain the audio or transcript associated with a command after it processes the command.
+- [Google Cloud Speech Service](https://cloud.google.com/terms/data-processing-terms): we share your audio recording with Google Cloud’s speech-to-text service to assist us in processing and carrying out your commands. Audio recordings are shared without personally identifiable metadata, and we've instructed Google's service not to retain the audio or transcript associated with a command after it processes the command
 - [Rev](https://www.rev.com/about/privacy): if you choose to allow Mozilla to store your audio recordings, we may share your recordings with Rev to manually review and transcribe them. Audio recordings are shared without personally identifiable metadata, and we've instructed Rev’s service not to retain the audio or transcript associated with a command after it reviews the command.
+
+If you have any questions about this privacy notice, please email us at compliance@mozilla.com. To read more about Mozilla’s privacy policy, click [here](https://www.mozilla.org/en-US/privacy/).


### PR DESCRIPTION
This makes it clearer that the privacy policy in the extension tells the general story, and the full Mozilla policy extends and clarifies it, instead of the other way around.
