### PR TITLE
Add email intents and services

### DIFF
--- a/bin/parse-intent-toml.js
+++ b/bin/parse-intent-toml.js
@@ -75,8 +75,8 @@ for (const filename of glob.sync(SERVICE_DIR + "/*/*.toml")) {
   const name = Object.keys(data)[0];
   const type = data[name].type;
   data[name].names = (data[name].names || []).concat([name]);
-  if (type !== "music") {
-    throw new Error(`Expected type=music in ${filename}`);
+  if (type !== "music" && type !== "email") {
+    throw new Error(`Expected type=music/email in ${filename}`);
   }
   delete data[name].type;
   Object.assign(serviceMetadata.music, data);

--- a/extension/background/serviceList.js
+++ b/extension/background/serviceList.js
@@ -29,8 +29,6 @@ const MUSIC_SERVICE_ALIASES = {
   video: "youtube",
 };
 
-const DEFAULT_MUSIC_SERVICE = "spotify";
-
 // Note these are maintained separately from the services in extension/services/*, because
 // those are all loaded too late to be used here
 export function musicServiceNames() {
@@ -39,6 +37,15 @@ export function musicServiceNames() {
 
 export function mapMusicServiceName(utterance) {
   return MUSIC_SERVICE_ALIASES[utterance.toLowerCase()];
+}
+
+const EMAIL_SERVICE_ALIAS = {
+  gmail: "gmail",
+  "google mail": "gmail",
+};
+
+export function mapEmailServiceName(utterance) {
+  return EMAIL_SERVICE_ALIAS[utterance.toLowerCase()];
 }
 
 export class Service {
@@ -176,10 +183,10 @@ export async function detectServiceFromActiveTab(services) {
   return null;
 }
 
-export async function detectServiceFromHistory(services) {
+export async function detectServiceFromHistory(services, defaultService) {
   const now = Date.now();
   const oneMonth = now - 1000 * 60 * 60 * 24 * 30; // last 30 days
-  let best = DEFAULT_MUSIC_SERVICE;
+  let best = defaultService;
   let bestScore = 0;
   for (const name in services) {
     const service = services[name];
@@ -224,7 +231,10 @@ export async function getService(serviceType, serviceMap, options) {
   if (serviceSetting && serviceSetting !== "auto") {
     return serviceMap[serviceSetting];
   }
-  const serviceName = await detectServiceFromHistory(serviceMap);
+  const serviceName = await detectServiceFromHistory(
+    serviceMap,
+    options.defaultService
+  );
   const ServiceClass = serviceMap[serviceName];
   if (!ServiceClass) {
     throw new Error(

--- a/extension/browserUtil.js
+++ b/extension/browserUtil.js
@@ -149,6 +149,9 @@ export class TabDataMap {
 }
 
 export function waitForDocumentComplete(tabId) {
+  if (!tabId) {
+    throw new Error("Bad waitForDocumentComplete(null)");
+  }
   return browser.tabs.executeScript(tabId, {
     code: "null",
     runAt: "document_idle",

--- a/extension/intents/bookmarks/bookmarks.js
+++ b/extension/intents/bookmarks/bookmarks.js
@@ -74,6 +74,62 @@ intentRunner.registerIntent({
 });
 
 intentRunner.registerIntent({
+  name: "bookmarks.createInFolder",
+  async run(context) {
+    const activeTab = await context.activeTab();
+    const metadata = await pageMetadata.getMetadata(activeTab.id);
+    const bookmarks = await browser.bookmarks.search({ url: metadata.url });
+    if (bookmarks.length) {
+      const exc = new Error("Bookmark already exists");
+      exc.displayMessage = "Bookmark already exists";
+      throw exc;
+    }
+    let folders = await browser.bookmarks.search({});
+    folders = folders.filter(b => b.type === "folder");
+    console.log("folders:", folders);
+    log.debug("Folder names:", folders.map(f => f.title));
+    const folderContent = [];
+    for (const folder of folders) {
+      folderContent.push({
+        id: folder.id,
+        title: folder.title.split(" "),
+      });
+    }
+    const fuseOptions = {
+      id: "id",
+      shouldSort: true,
+      tokenize: true,
+      findAllMatches: true,
+      includeScore: true,
+      threshold: 0.3,
+      location: 0,
+      distance: 100,
+      maxPatternLength: 32,
+      minMatchCharLength: 3,
+      keys: [
+        {
+          name: "title",
+          weight: 0.8,
+        },
+      ],
+    };
+    const fuse = new Fuse(folderContent, fuseOptions);
+    const matches = fuse.search(context.slots.folder);
+    if (!matches.length) {
+      const e = new Error("No matching folder found");
+      e.displayMessage = `No folder named "${context.slots.folder}" found`;
+      throw e;
+    }
+    const parentId = matches[0].item;
+    await browser.bookmarks.create({
+      title: metadata.title,
+      url: metadata.url,
+      parentId,
+    });
+  },
+});
+
+intentRunner.registerIntent({
   name: "bookmarks.remove",
   async run(context) {
     await context.displayText("Do you wish to remove this bookmark?");

--- a/extension/intents/bookmarks/bookmarks.toml
+++ b/extension/intents/bookmarks/bookmarks.toml
@@ -2,7 +2,7 @@
 description = "Creates a bookmark placing it in the default folder (Other Bookmarks)"
 match = """
   bookmark (this |) (page | site | tab |) (for me |)
-  (save | add) (this |) (page | site | tab |) to bookmarks
+  (save | add) (this |) (page | site | tab |) (in | to) bookmarks
 """
 
 [[bookmarks.create.example]]
@@ -31,6 +31,17 @@ test = true
 [[bookmarks.create.example]]
 phrase = "Bookmark site"
 test = true
+
+[bookmarks.createInFolder]
+description = "Creates a bookmark and puts it in a specific folder"
+match = """
+  (save | add | put | create | ) (this |) bookmark (this |) (page | site | tab |) (in | to) (folder |) [folder]
+  (save | add | put) (this |) (page | site | tab |) (in | to) bookmark{s} folder [folder]
+"""
+
+[[bookmarks.createInFolder.example]]
+phrase = "Bookmark this in a folder"
+expectSlots = {folder = "a folder"}
 
 [bookmarks.open]
 description = "This will search all your bookmarks for the given query, and open what appears to be the best match. Only title and URL are searched"

--- a/extension/intents/email/email.js
+++ b/extension/intents/email/email.js
@@ -1,0 +1,75 @@
+/* globals log */
+
+import * as pageMetadata from "../../background/pageMetadata.js";
+import * as intentRunner from "../../background/intentRunner.js";
+import * as serviceList from "../../background/serviceList.js";
+
+const SERVICES = {};
+
+export function register(service) {
+  if (!service.id) {
+    log.error("Bad email service, no id:", service);
+    throw new Error("Invalid service: no id");
+  }
+  if (SERVICES[service.id]) {
+    throw new Error(
+      `Attempt to register two email services with id ${service.id}`
+    );
+  }
+  SERVICES[service.id] = service;
+}
+
+async function getService(context, options) {
+  let ServiceClass;
+  const explicitService = context.slots.service || context.parameters.service;
+  options.defaultService = options.defaultService || "gmail";
+  if (explicitService) {
+    ServiceClass = SERVICES[serviceList.mapEmailServiceName(explicitService)];
+    if (!ServiceClass) {
+      throw new Error(
+        `[service] slot refers to unknown service: ${explicitService}`
+      );
+    }
+  } else {
+    ServiceClass = await serviceList.getService(
+      "emailService",
+      SERVICES,
+      options
+    );
+  }
+  return new ServiceClass(context);
+}
+
+function normalizeAddress(address) {
+  if (!address.includes("@")) {
+    address = address.replace(/\s+at\s+/i, "@");
+  }
+  address = address.replace(/\s+/g, "");
+  return address;
+}
+
+intentRunner.registerIntent({
+  name: "email.compose",
+  async run(context) {
+    const service = await getService(context, { lookAtCurrentTab: false });
+    let subject = context.slots.subject;
+    if (subject && subject.toLowerCase() === "this") {
+      context.parameters.body = "tab";
+      subject = null;
+    }
+    let body = "";
+    if (context.parameters.body === "tab") {
+      const active = await context.activeTab();
+      const metadata = await pageMetadata.getMetadata(active.id);
+      if (!subject) {
+        subject = metadata.title;
+      }
+      body = `${metadata.title}: ${metadata.url}\n\n`;
+    }
+    await service.compose({
+      to: normalizeAddress(context.slots.to),
+      subject,
+      body,
+    });
+  },
+});

--- a/extension/intents/email/email.toml
+++ b/extension/intents/email/email.toml
@@ -1,0 +1,26 @@
+[email.compose]
+description = "Compose a new email"
+match = """
+  (write | send | compose | start | launch |) (new |) (email | mail | send)
+  (write | send | compose | start | launch |) (new |) (email | mail | send) this (tab | site | page | article |) [body=tab]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) (to | for) [to]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) this (tab | site | page | article |) (to | for) [to] [body=tab]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) (to | for) [to] (about | subject) [subject]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) this (tab | site | page | article |) (to | for) [to] (about | subject) [subject] [body=tab]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) (to | for) [to] (about | subject) [subject]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) this (tab | site | page | article |) (to | for) [to] (about | subject) [subject] [body=tab]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) (about | subject) [subject]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) this (tab | site | page | article |) (about | subject) [subject] [body=tab]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) (about | subject) [subject] (to | for) [to]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) this (tab | site | page | article |) (about | subject) [subject] (to | for) [to] [body=tab]
+  (email | mail) [to]
+"""
+
+[[email.compose.example]]
+phrase = "Send email"
+
+[[email.compose.example]]
+# This is a typical transcription, but it gets normalized in the intent:
+phrase = "Email Bob At Example. Com"
+expectSlots = { to = "Bob" }
+test = true

--- a/extension/intents/music/music.js
+++ b/extension/intents/music/music.js
@@ -33,6 +33,7 @@ export function getServiceNamesAndTitles() {
 async function getService(context, options) {
   let ServiceClass;
   const explicitService = context.slots.service || context.parameters.service;
+  options.defaultService = options.defaultService || "spotify";
   if (explicitService) {
     ServiceClass = SERVICES[serviceList.mapMusicServiceName(explicitService)];
     if (!ServiceClass) {

--- a/extension/intents/navigation/followLink.js
+++ b/extension/intents/navigation/followLink.js
@@ -80,6 +80,6 @@ this.followLink = (function() {
   }
 
   function findLinks() {
-    return document.body.querySelectorAll("a");
+    return document.body.querySelectorAll("button, a, *[role=button]");
   }
 })();

--- a/extension/intents/navigation/navigation.js
+++ b/extension/intents/navigation/navigation.js
@@ -171,6 +171,24 @@ intentRunner.registerIntent({
 });
 
 intentRunner.registerIntent({
+  name: "navigation.closeDialog",
+  async run(context) {
+    const activeTab = await browserUtil.activeTab();
+    await content.lazyInject(activeTab.id, [
+      "/intents/navigation/closeDialog.js",
+    ]);
+    const found = await browser.tabs.sendMessage(activeTab.id, {
+      type: "closeDialog",
+    });
+    if (found === false) {
+      const exc = new Error("Could not close dialog");
+      exc.displayMessage = "I couldn't figure out how to close the dialog";
+      throw exc;
+    }
+  },
+});
+
+intentRunner.registerIntent({
   name: "navigation.internetArchive",
   async run(context) {
     const activeTab = await context.activeTab();

--- a/extension/intents/navigation/navigation.toml
+++ b/extension/intents/navigation/navigation.toml
@@ -145,6 +145,15 @@ match = """
   (open | go to) link [query]
 """
 
+[navigation.closeDialog]
+description = "Closes a lightbox-style dialog box"
+match = """
+  (close | dismiss | cancel | stop) (dialog | lightbox | question)
+"""
+
+[[navigation.closeDialog.example]]
+phrase = "Close dialog"
+
 [[navigation.followLink.example]]
 phrase = "follow link latest news"
 

--- a/extension/intents/nicknames/nicknames.js
+++ b/extension/intents/nicknames/nicknames.js
@@ -52,7 +52,7 @@ function parseNumber(n) {
     return numberNames[n];
   }
   const number = parseInt(n, 10);
-  if (Math.isNaN(number)) {
+  if (isNaN(number)) {
     throw new Error(`Cannot understand number: ${n}`);
   }
   return number;

--- a/extension/popup/popupController.jsx
+++ b/extension/popup/popupController.jsx
@@ -68,7 +68,7 @@ export const PopupController = function() {
   const DEFAULT_TIMEOUT = 2500;
   // Timeout for the popup when there's text displaying:
   const TEXT_TIMEOUT = 7000;
-  const FOLLOWUP_TIMEOUT = 5000;
+  const FOLLOWUP_TIMEOUT = 50000;
   let overrideTimeout;
   let noVoiceInterval;
   const userSettingsPromise = util.makeNakedPromise();
@@ -219,7 +219,9 @@ export const PopupController = function() {
         } else {
           setRequestFollowup(false);
           setFollowupText(null);
-          closePopup();
+          if (!listenForFollowup) {
+            closePopup();
+          }
         }
         break;
       }
@@ -351,6 +353,7 @@ export const PopupController = function() {
         type: "addTelemetry",
         properties: { inputTyped: true },
       });
+      setDisplayText("");
       browser.runtime.sendMessage({
         type: "runIntent",
         text,
@@ -458,6 +461,7 @@ export const PopupController = function() {
   };
 
   const onNextSearchResultClick = () => {
+    setDisplayText("");
     browser.runtime.sendMessage({
       type: "runIntent",
       text: "next",
@@ -477,6 +481,8 @@ export const PopupController = function() {
       clearTimeout(closePopupId);
     }
     // TODO: offload mic and other resources before closing?
+    console.log("explicit close popup");
+    console.trace();
     closePopupId = setTimeout(() => {
       window.close();
     }, ms);
@@ -554,6 +560,7 @@ export const PopupController = function() {
         type: "addTelemetry",
         properties: { transcriptionConfidence: json.data[0].confidence },
       });
+      setDisplayText("");
       log.timing(`Sending runIntent(${json.data[0].text})`);
       await browser.runtime.sendMessage({
         type: "runIntent",

--- a/extension/popup/popupView.jsx
+++ b/extension/popup/popupView.jsx
@@ -140,6 +140,7 @@ const PopupHeader = ({ currentView, transcript, lastIntent }) => {
   };
 
   const onClickClose = () => {
+    console.log("close clicked");
     window.close();
   };
 

--- a/extension/services/gmail/contentScript.js
+++ b/extension/services/gmail/contentScript.js
@@ -1,0 +1,17 @@
+/* globals communicate */
+
+this.emailer = (function() {
+  const SUBJECT = 'textarea[name="to"]';
+
+  communicate.register(
+    "searchFor",
+    message => {
+      /*
+      const sub = document.querySelector(SUBJECT);
+      sub.value = message.searchFor;
+      sub.focus();
+      */
+    },
+    true
+  );
+})();

--- a/extension/services/gmail/gmail.js
+++ b/extension/services/gmail/gmail.js
@@ -1,0 +1,39 @@
+import * as email from "../../intents/email/email.js";
+import * as browserUtil from "../../browserUtil.js";
+import * as content from "../../background/content.js";
+
+class Gmail {
+  async compose(options) {
+    let to = "";
+    let searchFor = null;
+    if (options.to) {
+      if (options.to.includes("@")) {
+        to = options.to;
+      } else {
+        searchFor = options.to;
+      }
+    }
+    const subject = options.subject || "";
+    const body = options.body || "";
+    const url = `https://mail.google.com/mail/u/0/?view=cm&fs=1&tf=1&source=mailto&to=${encodeURIComponent(
+      to
+    )}&su=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+    console.log("!!! url:", url);
+    const tab = await browserUtil.createTab({ url });
+    if (searchFor) {
+      await content.lazyInject(tab.id, `/services/gmail/contentScript.js`);
+      await browser.tabs.sendMessage(tab.id, {
+        type: "searchFor",
+        searchFor,
+      });
+    }
+  }
+}
+
+Object.assign(Gmail, {
+  id: "gmail",
+  title: "Gmail",
+  baseUrl: "https://mail.google.com/",
+});
+
+email.register(Gmail);

--- a/extension/services/gmail/gmail.toml
+++ b/extension/services/gmail/gmail.toml
@@ -1,0 +1,4 @@
+[gmail]
+type = "email"
+title = "Gmail"
+baseUrl = "https://mail.google.com"


### PR DESCRIPTION
This adds an intent to compose an email, with an optional subject and to address, and optionally based on the current page.

Also the service framework is extended for email providers, and a gmail provider added. Not much functionality around those providers yet.
