### PR TITLE
Add email intents and services

### DIFF
--- a/bin/parse-intent-toml.js
+++ b/bin/parse-intent-toml.js
@@ -75,8 +75,8 @@ for (const filename of glob.sync(SERVICE_DIR + "/*/*.toml")) {
   const name = Object.keys(data)[0];
   const type = data[name].type;
   data[name].names = (data[name].names || []).concat([name]);
-  if (type !== "music") {
-    throw new Error(`Expected type=music in ${filename}`);
+  if (type !== "music" && type !== "email") {
+    throw new Error(`Expected type=music/email in ${filename}`);
   }
   delete data[name].type;
   Object.assign(serviceMetadata.music, data);

--- a/extension/background/serviceList.js
+++ b/extension/background/serviceList.js
@@ -29,8 +29,6 @@ const MUSIC_SERVICE_ALIASES = {
   video: "youtube",
 };
 
-const DEFAULT_MUSIC_SERVICE = "spotify";
-
 // Note these are maintained separately from the services in extension/services/*, because
 // those are all loaded too late to be used here
 export function musicServiceNames() {
@@ -39,6 +37,15 @@ export function musicServiceNames() {
 
 export function mapMusicServiceName(utterance) {
   return MUSIC_SERVICE_ALIASES[utterance.toLowerCase()];
+}
+
+const EMAIL_SERVICE_ALIAS = {
+  gmail: "gmail",
+  "google mail": "gmail",
+};
+
+export function mapEmailServiceName(utterance) {
+  return EMAIL_SERVICE_ALIAS[utterance.toLowerCase()];
 }
 
 export class Service {
@@ -176,10 +183,10 @@ export async function detectServiceFromActiveTab(services) {
   return null;
 }
 
-export async function detectServiceFromHistory(services) {
+export async function detectServiceFromHistory(services, defaultService) {
   const now = Date.now();
   const oneMonth = now - 1000 * 60 * 60 * 24 * 30; // last 30 days
-  let best = DEFAULT_MUSIC_SERVICE;
+  let best = defaultService;
   let bestScore = 0;
   for (const name in services) {
     const service = services[name];
@@ -224,7 +231,10 @@ export async function getService(serviceType, serviceMap, options) {
   if (serviceSetting && serviceSetting !== "auto") {
     return serviceMap[serviceSetting];
   }
-  const serviceName = await detectServiceFromHistory(serviceMap);
+  const serviceName = await detectServiceFromHistory(
+    serviceMap,
+    options.defaultService
+  );
   const ServiceClass = serviceMap[serviceName];
   if (!ServiceClass) {
     throw new Error(

--- a/extension/intents/email/email.js
+++ b/extension/intents/email/email.js
@@ -1,0 +1,75 @@
+/* globals log */
+
+import * as pageMetadata from "../../background/pageMetadata.js";
+import * as intentRunner from "../../background/intentRunner.js";
+import * as serviceList from "../../background/serviceList.js";
+
+const SERVICES = {};
+
+export function register(service) {
+  if (!service.id) {
+    log.error("Bad email service, no id:", service);
+    throw new Error("Invalid service: no id");
+  }
+  if (SERVICES[service.id]) {
+    throw new Error(
+      `Attempt to register two email services with id ${service.id}`
+    );
+  }
+  SERVICES[service.id] = service;
+}
+
+async function getService(context, options) {
+  let ServiceClass;
+  const explicitService = context.slots.service || context.parameters.service;
+  options.defaultService = options.defaultService || "gmail";
+  if (explicitService) {
+    ServiceClass = SERVICES[serviceList.mapEmailServiceName(explicitService)];
+    if (!ServiceClass) {
+      throw new Error(
+        `[service] slot refers to unknown service: ${explicitService}`
+      );
+    }
+  } else {
+    ServiceClass = await serviceList.getService(
+      "emailService",
+      SERVICES,
+      options
+    );
+  }
+  return new ServiceClass(context);
+}
+
+function normalizeAddress(address) {
+  if (!address.includes("@")) {
+    address = address.replace(/\s+at\s+/i, "@");
+  }
+  address = address.replace(/\s+/g, "");
+  return address;
+}
+
+intentRunner.registerIntent({
+  name: "email.compose",
+  async run(context) {
+    const service = await getService(context, { lookAtCurrentTab: false });
+    let subject = context.slots.subject;
+    if (subject && subject.toLowerCase() === "this") {
+      context.parameters.body = "tab";
+      subject = null;
+    }
+    let body = "";
+    if (context.parameters.body === "tab") {
+      const active = await context.activeTab();
+      const metadata = await pageMetadata.getMetadata(active.id);
+      if (!subject) {
+        subject = metadata.title;
+      }
+      body = `${metadata.title}: ${metadata.url}\n\n`;
+    }
+    await service.compose({
+      to: normalizeAddress(context.slots.to),
+      subject,
+      body,
+    });
+  },
+});

--- a/extension/intents/email/email.toml
+++ b/extension/intents/email/email.toml
@@ -1,0 +1,26 @@
+[email.compose]
+description = "Compose a new email"
+match = """
+  (write | send | compose | start | launch |) (new |) (email | mail | send)
+  (write | send | compose | start | launch |) (new |) (email | mail | send) this (tab | site | page | article |) [body=tab]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) (to | for) [to]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) this (tab | site | page | article |) (to | for) [to] [body=tab]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) (to | for) [to] (about | subject) [subject]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) this (tab | site | page | article |) (to | for) [to] (about | subject) [subject] [body=tab]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) (to | for) [to] (about | subject) [subject]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) this (tab | site | page | article |) (to | for) [to] (about | subject) [subject] [body=tab]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) (about | subject) [subject]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) this (tab | site | page | article |) (about | subject) [subject] [body=tab]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) (about | subject) [subject] (to | for) [to]
+  (write | send | compose | start | launch |) (new |) (email | mail | send) this (tab | site | page | article |) (about | subject) [subject] (to | for) [to] [body=tab]
+  (email | mail) [to]
+"""
+
+[[email.compose.example]]
+phrase = "Send email"
+
+[[email.compose.example]]
+# This is a typical transcription, but it gets normalized in the intent:
+phrase = "Email Bob At Example. Com"
+expectSlots = { to = "Bob" }
+test = true

--- a/extension/intents/music/music.js
+++ b/extension/intents/music/music.js
@@ -33,6 +33,7 @@ export function getServiceNamesAndTitles() {
 async function getService(context, options) {
   let ServiceClass;
   const explicitService = context.slots.service || context.parameters.service;
+  options.defaultService = options.defaultService || "spotify";
   if (explicitService) {
     ServiceClass = SERVICES[serviceList.mapMusicServiceName(explicitService)];
     if (!ServiceClass) {

--- a/extension/services/gmail/gmail.js
+++ b/extension/services/gmail/gmail.js
@@ -1,0 +1,22 @@
+import * as email from "../../intents/email/email.js";
+import * as browserUtil from "../../browserUtil.js";
+
+class Gmail {
+  async compose(options) {
+    const to = options.to;
+    const subject = options.subject || "";
+    const body = options.body || "";
+    const url = `https://mail.google.com/mail/u/0/?view=cm&fs=1&tf=1&source=mailto&to=${encodeURIComponent(
+      to
+    )}&su=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+    await browserUtil.createTab({ url });
+  }
+}
+
+Object.assign(Gmail, {
+  id: "gmail",
+  title: "Gmail",
+  baseUrl: "https://mail.google.com/",
+});
+
+email.register(Gmail);

--- a/extension/services/gmail/gmail.toml
+++ b/extension/services/gmail/gmail.toml
@@ -1,0 +1,4 @@
+[gmail]
+type = "email"
+title = "Gmail"
+baseUrl = "https://mail.google.com"


### PR DESCRIPTION
This adds an intent to compose an email, with an optional subject and to address, and optionally based on the current page.

Also the service framework is extended for email providers, and a gmail provider added. Not much functionality around those providers yet.
