### PR TITLE
Fixes #1694 find intent the same in search and find files

### DIFF
--- a/extension/intents/find/find.toml
+++ b/extension/intents/find/find.toml
@@ -1,7 +1,8 @@
 [find.find]
 description = "Find the open tab that matches the query (searching the title, URL, and page content), and make that tab (and window) active"
 match = """
-  (find | bring me to | bring up | switch to) (my | the |) [query] (tab |)
+  find (my | the |) [query] tab
+  (bring me to | bring up | switch to) (my | the |) [query] (tab |)
   (find | open | focus | show | switch to) tab [query]
   go (to | to the |) [query] tab
   go to my [query]


### PR DESCRIPTION
Fixes #1694 

The "Find [query] " intent was the same in both search.toml and find.toml so in order to differentiate between behaviours, I added the "tab";
therefore the user has to use the word "tab" to find something in their tabs
