### PR TITLE
Fixes #1683 previous tab fix when tab is closed

### DIFF
--- a/extension/intents/tabs/tabs.js
+++ b/extension/intents/tabs/tabs.js
@@ -271,6 +271,11 @@ intentRunner.registerIntent({
       if (tabId === activeTab.id) {
         continue;
       }
+      try {
+        await browser.tabs.get(tabId);
+      } catch (e) {
+        continue;
+      }
       found = tabId;
       break;
     }


### PR DESCRIPTION
Fixes #1683

The "previous tab" intent finds a more-previous tab now and goes there when the tab is closed.