### PR TITLE
Fixes #1778 selecting specified tabs

### DIFF
--- a/extension/intents/tabs/tabs.js
+++ b/extension/intents/tabs/tabs.js
@@ -576,6 +576,16 @@ if (!buildSettings.android) {
 }
 
 intentRunner.registerIntent({
+  name: "tabs.refreshSelectedTabs",
+  async run(context) {
+    const tabs = await browser.tabs.query({ highlighted: true });
+    for (const tab of tabs) {
+      await browser.tabs.reload(tab.id);
+    }
+  },
+});
+
+intentRunner.registerIntent({
   name: "tabs.countTabs",
   async run(context) {
     context.keepPopup();
@@ -832,6 +842,25 @@ intentRunner.registerIntent({
       context.slots.number || context.parameters.number
     );
     await selectNumbersTabs(tabs, numTabs, context.parameters.dir);
+  },
+});
+
+intentRunner.registerIntent({
+  name: "tabs.selectSpecificTabs",
+  async run(context) {
+    const matchingTabs = await getMatchingTabs({
+      query: context.slots.query,
+      sort_by_index: false,
+      allWindows: context.parameters.allWindows === "true",
+    });
+
+    if (matchingTabs.length === 0) {
+      const exc = new Error("No tab that matches the query");
+      exc.displayMessage = "There is no tab that matches the query";
+      throw exc;
+    }
+
+    await selectAllTabs(matchingTabs);
   },
 });
 

--- a/extension/intents/tabs/tabs.toml
+++ b/extension/intents/tabs/tabs.toml
@@ -351,7 +351,7 @@ test = true
 [tabs.closeSelectedTabs]
 description = "Close selected tabs"
 match = """
-  (close | remove) (all |) (the |) selected tabs
+  (close | remove) (all |) (the |) selected (tabs | pages |)
 """
 
 [[tabs.closeSelectedTabs.example]]
@@ -359,6 +359,19 @@ phrase = "Close all selected tabs"
 
 [[tabs.closeSelectedTabs.example]]
 phrase = "Remove the selected tabs"
+test = true
+
+[tabs.refreshSelectedTabs]
+description = "Refresh selected tabs"
+match = """
+  (refresh | reload) (all |) (the |) selected (tabs | pages |)
+"""
+
+[[tabs.refreshSelectedTabs.example]]
+phrase = "Refresh all selected tabs"
+
+[[tabs.refreshSelectedTabs.example]]
+phrase = "Reload the selected tabs"
 test = true
 
 [tabs.countTabs]
@@ -474,3 +487,10 @@ expectParameters = { dir = "first" }
 [[tabs.selectNumbersTabs.example]]
 phrase = "select last two tabs"
 expectParameters = { dir = "last" }
+
+[tabs.selectSpecificTabs]
+description = "Select specific tabs after query"
+match = """
+  (select | highlight) (all |) [query] (tab{s} | page{s}) (in | from) all (the|) window{s} [allWindows=true]
+  (select | highlight) (all |) [query] (tab{s} | page{s}) [allWindows=false]
+"""


### PR DESCRIPTION
Added "select [query] tabs"  and "refresh selected tabs" to be able to close / refresh tabs by query. 