### PR TITLE
Fix #1337, fix search selection in Spotify

### DIFF
--- a/extension/services/spotify/player.js
+++ b/extension/services/spotify/player.js
@@ -17,7 +17,7 @@ this.player = (function() {
       }
 
       const searchButton = await this.waitForSelector(
-        "a[aria-label='Search']",
+        "a[aria-label='Search'], a[href$='search']",
         {
           timeout: 5000,
         }


### PR DESCRIPTION
Spotify seems to use different markup sometimes for the search field/button
