### PR TITLE
Fix #1343, fix follow link failure

### DIFF
--- a/extension/intents/navigation/followLink.js
+++ b/extension/intents/navigation/followLink.js
@@ -18,15 +18,15 @@ this.followLink = (function() {
       keys: [
         {
           name: "title",
-          weight: 0.8,
+          weight: 0.45,
         },
         {
           name: "text",
-          weight: 0.8,
+          weight: 0.45,
         },
         {
           name: "url",
-          weight: 0.2,
+          weight: 0.1,
         },
       ],
     };


### PR DESCRIPTION
Fuse only allows weights to be as high as a total of 1.0. Not sure why this worked sometimes.
